### PR TITLE
Add 'releases' repo to publishing URL

### DIFF
--- a/scripts/circle-publish-dist.sh
+++ b/scripts/circle-publish-dist.sh
@@ -8,7 +8,7 @@ fi
 artifact_version=$CIRCLE_TAG
 artifact_file="conjure-typescript-$artifact_version.tgz"
 
-upload_url="https://api.bintray.com/content/palantir/releases/conjure-typescript/com/palantir/conjure/typescript/conjure-typescript/${artifact_version}/${artifact_file}"
+upload_url="https://api.bintray.com/content/palantir/releases/conjure-typescript/${artifact_version}/com/palantir/conjure/typescript/conjure-typescript/${artifact_version}/${artifact_file}"
 echo "publishing $1 to $upload_url"
 set +x
 curl --fail -v -X PUT "$upload_url?publish=1" -T "$1" -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD


### PR DESCRIPTION
From the docs (https://bintray.com/docs/api/#_upload_content):

```
curl -XPUT /content/:subject/:repo/:package/:version/:file_path[?publish=0/1]
```

We were missing `:repo` and `:version` I think