### PR TITLE
isolate compiled javascript

### DIFF
--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -39,9 +39,11 @@ describe("generate command", () => {
         expect(createPackageJson(inputPackage, "foo", "1.0.0")).toEqual({
             name: "foo",
             version: "1.0.0",
+            main: "dist/index.js",
+            types: "dist/index.d.ts",
             sideEffects: false,
             scripts: {
-                build: "tsc",
+                build: "tsc -p src",
             },
             peerDependencies: { "conjure-client": "1.0.0" },
             devDependencies: {
@@ -65,9 +67,9 @@ describe("generate command", () => {
             packageName: "foo",
             packageVersion: "1.0.0",
         });
-        expect(fs.existsSync(path.join(outDir, "index.ts"))).toBeTruthy();
+        expect(fs.existsSync(path.join(outDir, "src/index.ts"))).toBeTruthy();
+        expect(fs.existsSync(path.join(outDir, "src/tsconfig.json"))).toBeTruthy();
         expect(fs.existsSync(path.join(outDir, "package.json"))).toBeTruthy();
-        expect(fs.existsSync(path.join(outDir, "tsconfig.json"))).toBeTruthy();
     });
 
     it("generated code installs dependencies", async () => {
@@ -91,7 +93,7 @@ describe("generate command", () => {
         });
         await executeCommand("yarn install --no-lockfile", outDir);
         await executeCommand("yarn build", outDir);
-        expect(fs.existsSync(path.join(outDir, "index.js"))).toBeTruthy();
+        expect(fs.existsSync(path.join(outDir, "dist/index.js"))).toBeTruthy();
     });
 
     it("throws on missing directory", async () => {

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -88,13 +88,15 @@ export class GenerateCommand implements CommandModule {
             ...JSON.parse(contents),
         };
 
+        const srcDir = path.join(output, "src");
+        fs.mkdirpSync(srcDir);
         return Promise.all([
             writeJson(
                 path.join(output, "package.json"),
                 createPackageJson(require("../../../package.json"), packageName, packageVersion),
             ),
-            writeJson(path.join(output, "tsconfig.json"), createTsconfigJson(nodeCompatibleModules)),
-            generate(conjureDefinition, output),
+            writeJson(path.join(srcDir, "tsconfig.json"), createTsconfigJson(nodeCompatibleModules)),
+            generate(conjureDefinition, srcDir),
         ]);
     };
 }
@@ -106,9 +108,11 @@ export function createPackageJson(projectPackageJson: IPackageJson, packageName:
     return {
         name: `${packageName}`,
         version,
+        main: "dist/index.js",
+        types: "dist/index.d.ts",
         sideEffects: false,
         scripts: {
-            build: "tsc",
+            build: "tsc -p src",
         },
         peerDependencies,
         devDependencies: {
@@ -126,6 +130,7 @@ export function createTsconfigJson(generateNodeCompatibleModule: boolean | undef
             declaration: true,
             inlineSourceMap: true,
             inlineSources: true,
+            outDir: "../dist",
             module: generateNodeCompatibleModule ? "commonjs" : "es2015",
             moduleResolution: "node",
             noImplicitAny: true,


### PR DESCRIPTION
Closes #24.

Example project structure:
```
├── dist/
│   ├── another/
│   ├── index.d.ts
│   ├── index.js
│   ├── product/
│   └── product-datasets/
├── node_modules/
│   ├── conjure-client/
│   ├── typescript/
│   └── uuidjs/
├── package.json
└── src/
    ├── another/
    ├── index.ts
    ├── product/
    ├── product-datasets/
    └── tsconfig.json

```

example package.json:
```
{
  "name": "foo",
  "version": "1.0.0",
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
  "sideEffects": false,
  "scripts": {
    "build": "tsc -p src"
  },
  "peerDependencies": {
    "conjure-client": "^0.2.0"
  },
  "devDependencies": {
    "conjure-client": "^0.2.0",
    "typescript": "~2.9.1"
  },
  "author": "Conjure",
  "license": "UNLICENSED"
}
```