### PR TITLE
Remove inlineSourceMap and inlineSources for generated JS

### DIFF
--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -128,8 +128,6 @@ export function createTsconfigJson(generateNodeCompatibleModule: boolean | undef
     return {
         compilerOptions: {
             declaration: true,
-            inlineSourceMap: true,
-            inlineSources: true,
             outDir: "../dist",
             module: generateNodeCompatibleModule ? "commonjs" : "es2015",
             moduleResolution: "node",


### PR DESCRIPTION
CC @ferozco @iamdanfox -- don't know who's best to review

The generated source maps for all of our conjure libs are a little heavy -- I'm spending some time looking at optimizing our builds across the platform for speedier dev iteration + production boot, and this seems like some low-hanging fruit. I'm not quite sure what value the mapping provides, so I more than welcome pushback here.
