### PR TITLE
add option to generate .gitignore

### DIFF
--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -66,6 +66,8 @@ describe("generate command", () => {
             _: ["generate", input, outDir],
             packageName: "foo",
             packageVersion: "1.0.0",
+            nodeCompatibleModules: false,
+            generateGitIgnore: false,
         });
         expect(fs.existsSync(path.join(outDir, "src/index.ts"))).toBeTruthy();
         expect(fs.existsSync(path.join(outDir, "src/tsconfig.json"))).toBeTruthy();
@@ -78,6 +80,8 @@ describe("generate command", () => {
             _: ["generate", input, outDir],
             packageName: "foo",
             packageVersion: "1.0.0",
+            nodeCompatibleModules: false,
+            generateGitIgnore: false,
         });
         await executeCommand("yarn install --no-lockfile", outDir);
         expect(fs.existsSync(path.join(outDir, "node_modules"))).toBeTruthy();
@@ -90,10 +94,34 @@ describe("generate command", () => {
             _: ["generate", input, outDir],
             packageName: "foo",
             packageVersion: "1.0.0",
+            nodeCompatibleModules: false,
+            generateGitIgnore: false,
         });
         await executeCommand("yarn install --no-lockfile", outDir);
         await executeCommand("yarn build", outDir);
         expect(fs.existsSync(path.join(outDir, "dist/index.js"))).toBeTruthy();
+    });
+
+    it("generates .gitignore files", async () => {
+        await generateCommand.handler({
+            _: ["generate", input, outDir],
+            packageName: "foo",
+            packageVersion: "1.0.0",
+            nodeCompatibleModules: false,
+            generateGitIgnore: true,
+        });
+        expect(fs.existsSync(path.join(outDir, ".gitignore"))).toBeTruthy();
+    });
+
+    it("tolerates existing .gitignore files", async () => {
+        fs.writeFileSync(path.join(outDir, ".gitignore"), "");
+        await generateCommand.handler({
+            _: ["generate", input, outDir],
+            packageName: "foo",
+            packageVersion: "1.0.0",
+            nodeCompatibleModules: false,
+            generateGitIgnore: true,
+        });
     });
 
     it("throws on missing directory", async () => {
@@ -102,6 +130,8 @@ describe("generate command", () => {
                 _: ["generate", input, "missing"],
                 packageName: "foo",
                 packageVersion: "1.0.0",
+                nodeCompatibleModules: false,
+                generateGitIgnore: false,
             }),
         ).rejects.toThrowError('Directory "missing" does not exist');
     });

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -26,14 +26,30 @@ import { generate } from "./generator";
 export * from "./generator";
 
 export interface IGenerateCommandArgs {
-    /* Positional arguments */
+    /*
+     * Positional arguments
+     */
     _: string[];
 
-    packageVersion: string;
-
+    /*
+     * The name of the package to generate
+     */
     packageName: string;
 
-    nodeCompatibleModules?: boolean;
+    /*
+     * The version of the package to generate
+     */
+    packageVersion: string;
+
+    /*
+     * Configure TypeScript compilation to generate modules that are node compatible
+     */
+    nodeCompatibleModules: boolean;
+
+    /*
+     * Generate a .gitignore file to exclude all generated code from a git tree
+     */
+    generateGitIgnore: boolean;
 }
 
 export class GenerateCommand implements CommandModule {
@@ -64,15 +80,20 @@ export class GenerateCommand implements CommandModule {
                 type: "string",
             })
             .option("nodeCompatibleModules", {
-                default: undefined,
+                default: false,
                 describe: "Generate node compatible javascript",
+                type: "boolean",
+            })
+            .option("generateGitIgnore", {
+                default: false,
+                describe: "Generate .gitignore file to exclude all generated code from a git tree",
                 type: "boolean",
             })
             .demand(2);
     }
 
     public handler = async (args: IGenerateCommandArgs) => {
-        const { packageName, packageVersion, nodeCompatibleModules } = args;
+        const { packageName, packageVersion, nodeCompatibleModules, generateGitIgnore } = args;
         const [, input, output] = args._;
         if (!fs.existsSync(output)) {
             throw new Error(`Directory "${output}" does not exist`);
@@ -96,6 +117,7 @@ export class GenerateCommand implements CommandModule {
                 createPackageJson(require("../../../package.json"), packageName, packageVersion),
             ),
             writeJson(path.join(srcDir, "tsconfig.json"), createTsconfigJson(nodeCompatibleModules)),
+            maybeGenerateGitIgnore(output, generateGitIgnore),
             generate(conjureDefinition, srcDir),
         ]);
     };
@@ -124,7 +146,7 @@ export function createPackageJson(projectPackageJson: IPackageJson, packageName:
     };
 }
 
-export function createTsconfigJson(generateNodeCompatibleModule: boolean | undefined) {
+export function createTsconfigJson(generateNodeCompatibleModule: boolean) {
     return {
         compilerOptions: {
             declaration: true,
@@ -138,4 +160,11 @@ export function createTsconfigJson(generateNodeCompatibleModule: boolean | undef
             typeRoots: [],
         },
     };
+}
+
+async function maybeGenerateGitIgnore(output: string, generateGitIgnore: boolean) {
+    const ignoredFiles = ["*.js", "*.ts", ".npmrc", "package.json", "tsconfig.json", "node_modules", ".npmignore"];
+    if (generateGitIgnore) {
+        return fs.writeFile(path.join(output, ".gitignore"), ignoredFiles.join("\n"));
+    }
 }


### PR DESCRIPTION
It seems odd that the gradle-plugin has to know what files to ignore for each generate. This pushes that responsibility to the generator itself. 

This change was inspired by the desire to generate a .npmignore so that we could improve our package size as well as revert package structure changes for easier sub-module imports. 

In terms of the interaction with gradle-conjure, there is an issue that the .gitignore will now live under `api-typescript/src` rather than at the root of the subproject. I don't think its an issue but worth calling out