### PR TITLE
Bump conjure-client from 1.0.0 -> 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "commander": "^2.15.1",
     "conjure-api": "^0.4.3",
-    "conjure-client": "^1.0.0",
+    "conjure-client": "^1.2.0",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",

--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -33,7 +33,7 @@ describe("generate command", () => {
 
     it("generates correct packageJson", () => {
         const inputPackage: IPackageJson = {
-            dependencies: { "conjure-client": "1.0.0" },
+            dependencies: { "conjure-client": "1.2.0" },
             devDependencies: { typescript: "2.7.2" },
         };
         expect(createPackageJson(inputPackage, "foo", "1.0.0")).toEqual({
@@ -45,9 +45,9 @@ describe("generate command", () => {
             scripts: {
                 build: "tsc",
             },
-            peerDependencies: { "conjure-client": "1.0.0" },
+            peerDependencies: { "conjure-client": "1.2.0" },
             devDependencies: {
-                "conjure-client": "1.0.0",
+                "conjure-client": "1.2.0",
                 typescript: "2.7.2",
             },
             author: "Conjure",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,11 +1771,9 @@ conjure-api@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-0.4.3.tgz#1c541ec939db1852745a79c9bf9d9a8cbae93ca5"
 
-conjure-client@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-1.0.0.tgz#b6181f29167e520ec9992efb2a8fc1b6496d811a"
-  dependencies:
-    uuidjs "^4.0.3"
+conjure-client@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-1.2.0.tgz#ef03fc810d2cbc6ef0480cf33125428bc4240e19"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -6711,10 +6709,6 @@ uuid@^2.0.1:
 uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uuidjs@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/uuidjs/-/uuidjs-4.0.3.tgz#4b4113a98e70507643a9a55a0493ff95b1d2538d"
 
 v8-compile-cache@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Need to roll out this bugfix so that our conjure-verification tests can start compiling nicely https://github.com/palantir/conjure-typescript-client/pull/15