### PR TITLE
add link to sls-js for version error

### DIFF
--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -98,7 +98,8 @@ export class GenerateCommand implements CommandModule {
         } else if (!fs.existsSync(output)) {
             throw new Error(`Directory "${output}" does not exist`);
         } else if (!rawSource && !isValid(packageVersion!)) {
-            throw new Error(`Expected version to be valid SLS version but found "${packageVersion}"`);
+            throw new Error('Expected version to be valid SLS version but found "${packageVersion}. '
+                + "Please see https://github.com/palantir/sls-version-js for more details on SLS version.");
         }
 
         const contents = fs.readFileSync(input, "utf8");

--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -98,8 +98,10 @@ export class GenerateCommand implements CommandModule {
         } else if (!fs.existsSync(output)) {
             throw new Error(`Directory "${output}" does not exist`);
         } else if (!rawSource && !isValid(packageVersion!)) {
-            throw new Error('Expected version to be valid SLS version but found "${packageVersion}. '
-                + "Please see https://github.com/palantir/sls-version-js for more details on SLS version.");
+            throw new Error(
+                `Expected version to be valid SLS version but found "${packageVersion}. ` +
+                    "Please see https://github.com/palantir/sls-version-js for more details on SLS version.",
+            );
         }
 
         const contents = fs.readFileSync(input, "utf8");


### PR DESCRIPTION
## Before this PR
If a version provided is not SLS compliant such as starting a new project, an nice error will be thrown. However it is rather cryptic to external users who are not familiar with SLS version.

## After this PR
A link to sls-version-js is provided as part of the error message, so users can learn more about the SLS version the readme. (The current readme doesn't have much info regarding the sls version and there is a separate [PR](https://github.com/palantir/sls-version-js/pull/3) for that) 