### PR TITLE
[fix] Make enum values used as map keys optional

### DIFF
--- a/src/commands/generate/__tests__/resources/types/enumMapObject.ts
+++ b/src/commands/generate/__tests__/resources/types/enumMapObject.ts
@@ -1,5 +1,5 @@
 import { EnumWithDocs } from "./enumWithDocs";
 
 export interface IEnumMapObject {
-    'someMap': { [key in EnumWithDocs]: string };
+    'someMap': { [key in EnumWithDocs]?: string };
 }

--- a/src/commands/generate/__tests__/tsTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsTypeVisitorTest.ts
@@ -105,7 +105,7 @@ describe("TsTypeVisitor", () => {
 
     it("returns map type with enum keys", () => {
         const tsType = visitor.map({ keyType: enumReference, valueType: objectReference });
-        expect(tsType).toEqual(`{ [key in ${enumName.name}]: IObject }`);
+        expect(tsType).toEqual(`{ [key in ${enumName.name}]?: IObject }`);
     });
 
     it("follows primitive external fallback", () => {

--- a/src/commands/generate/tsTypeVisitor.ts
+++ b/src/commands/generate/tsTypeVisitor.ts
@@ -61,7 +61,7 @@ export class TsTypeVisitor implements ITypeVisitor<string> {
         if (IType.isReference(obj.keyType)) {
             const keyTypeDefinition = this.knownTypes.get(createHashableTypeName(obj.keyType.reference));
             if (keyTypeDefinition != null && ITypeDefinition.isEnum(keyTypeDefinition)) {
-                return `{ [key in ${obj.keyType.reference.name}]: ${valueTsType} }`;
+                return `{ [key in ${obj.keyType.reference.name}]?: ${valueTsType} }`;
             }
         }
         return `{ [key: ${keyTsType}]: ${valueTsType} }`;


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
When using enum values as map keys the generated java objects and typescript interfaces were inconsistent in behaviour.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
When using enum values as map keys the generated typescript interface now has optional properties so  none/some/all of the keys can be present to match the expected java behaviour.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
Fixes #52 