### PR TITLE
[improvement] Generate more lenient  enums

### DIFF
--- a/src/commands/generate/__tests__/resources/types/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/types/enumExample.ts
@@ -1,4 +1,6 @@
-export enum EnumExample {
-    ONE = "ONE",
-    TWO = "TWO"
-}
+export type EnumExample = "ONE" | "TWO";
+
+export const EnumExample = {
+    ONE: "ONE" as "ONE",
+    TWO: "TWO" as "TWO"
+};

--- a/src/commands/generate/__tests__/resources/types/enumWithDocs.ts
+++ b/src/commands/generate/__tests__/resources/types/enumWithDocs.ts
@@ -1,10 +1,9 @@
 /**
  * Some documentation
  */
-export enum EnumWithDocs {
-    /**
-     * Some field documentation
-     */
-    FOO = "FOO",
-    BAR = "BAR"
-}
+export type EnumWithDocs = "FOO" | "BAR";
+
+export const EnumWithDocs = {
+    FOO: "FOO" as "FOO",
+    BAR: "BAR" as "BAR"
+};

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -29,7 +29,6 @@ import { SimpleAst } from "./simpleAst";
 import { TsTypeVisitor } from "./tsTypeVisitor";
 import { doubleQuote, isValidFunctionName, singleQuote } from "./utils";
 
-
 export function generateType(
     definition: ITypeDefinition,
     knownTypes: Map<string, ITypeDefinition>,


### PR DESCRIPTION
## Before this PR
We generated TypeScript enums which were difficult to use across library boundaries since equivalent enums could no be assigned to each other. See #80 for more details

## After this PR
We generate a union type and a constant map