### PR TITLE
[fix] Fix npm registry publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
+*
 !LICENSE
 !README.md
 !bin/*
-!lib/*
-!lib/generate/**/*
-!lib/__generated__/**/*
-*
+!lib/**/*
+**/__tests__/*
+**/__mocks__/*

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "conjure-typescript": "./bin/conjure-typescript"
   },
   "sideEffects": false,
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/conjureTypeScript.js",
+  "types": "lib/conjureTypeScript.d.ts",
   "scripts": {
     "build": "npm-run-all clean compile verify",
     "circle-publish": "./scripts/circle-publish-npm && ./scripts/circle-publish-dist",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
     "conjure-typescript": "./bin/conjure-typescript"
   },
   "sideEffects": false,
-  "main": "lib/conjureTypeScript.js",
-  "types": "lib/conjureTypeScript.d.ts",
   "scripts": {
     "build": "npm-run-all clean compile verify",
     "circle-publish": "./scripts/circle-publish-npm && ./scripts/circle-publish-dist",


### PR DESCRIPTION
## Before this PR
Packages published to NPM were empty. 

## After this PR

The following files are published (result of `npm publish --dry-run`)

```
npm notice 
npm notice 📦  conjure-typescript@0.0.0
npm notice === Tarball Contents === 
npm notice 2.7kB  package.json                                            
npm notice 11.4kB LICENSE                                                 
npm notice 6.0kB  README.md                                               
npm notice 58B    bin/conjure-typescript                                  
npm notice 878B   lib/commands/generate/errorGenerator.d.ts               
npm notice 2.9kB  lib/commands/generate/errorGenerator.js                 
npm notice 1.9kB  lib/commands/generate/errorGenerator.js.map             
npm notice 1.9kB  lib/commands/generate/generateCommand.d.ts              
npm notice 13.0kB lib/commands/generate/generateCommand.js                
npm notice 4.7kB  lib/commands/generate/generateCommand.js.map            
npm notice 771B   lib/commands/generate/generator.d.ts                    
npm notice 7.2kB  lib/commands/generate/generator.js                      
npm notice 2.9kB  lib/commands/generate/generator.js.map                  
npm notice 1.9kB  lib/commands/generate/imports.d.ts                      
npm notice 5.9kB  lib/commands/generate/imports.js                        
npm notice 4.5kB  lib/commands/generate/imports.js.map                    
npm notice 659B   lib/commands/generate/index.d.ts                        
npm notice 871B   lib/commands/generate/index.js                          
npm notice 166B   lib/commands/generate/index.js.map                      
npm notice 884B   lib/commands/generate/serviceGenerator.d.ts             
npm notice 8.5kB  lib/commands/generate/serviceGenerator.js               
npm notice 6.3kB  lib/commands/generate/serviceGenerator.js.map           
npm notice 981B   lib/commands/generate/simpleAst.d.ts                    
npm notice 6.2kB  lib/commands/generate/simpleAst.js                      
npm notice 2.4kB  lib/commands/generate/simpleAst.js.map                  
npm notice 1.2kB  lib/commands/generate/stringConversionTypeVisitor.d.ts  
npm notice 2.1kB  lib/commands/generate/stringConversionTypeVisitor.js    
npm notice 976B   lib/commands/generate/stringConversionTypeVisitor.js.map
npm notice 1.4kB  lib/commands/generate/tsTypeVisitor.d.ts                
npm notice 4.5kB  lib/commands/generate/tsTypeVisitor.js                  
npm notice 2.8kB  lib/commands/generate/tsTypeVisitor.js.map              
npm notice 1.9kB  lib/commands/generate/typeGenerator.d.ts                
npm notice 14.5kB lib/commands/generate/typeGenerator.js                  
npm notice 7.6kB  lib/commands/generate/typeGenerator.js.map              
npm notice 1.1kB  lib/commands/generate/utils.d.ts                        
npm notice 2.4kB  lib/commands/generate/utils.js                          
npm notice 1.3kB  lib/commands/generate/utils.js.map                      
npm notice 652B   lib/commands/index.d.ts                                 
npm notice 864B   lib/commands/index.js                                   
npm notice 154B   lib/commands/index.js.map                               
npm notice 635B   lib/conjureTypeScript.d.ts                              
npm notice 3.6kB  lib/conjureTypeScript.js                                
npm notice 375B   lib/conjureTypeScript.js.map                            
npm notice 692B   lib/utils/index.d.ts                                    
npm notice 868B   lib/utils/index.js                                      
npm notice 151B   lib/utils/index.js.map                                  
npm notice 1.4kB  lib/utils/packageUtils.d.ts                             
npm notice 3.5kB  lib/utils/packageUtils.js                               
npm notice 355B   lib/utils/packageUtils.js.map                           
npm notice 402B   lib/utils/slslDependencies.d.ts                         
npm notice 205B   lib/utils/slslDependencies.js                           
npm notice 144B   lib/utils/slslDependencies.js.map                       
npm notice === Tarball Details === 
npm notice name:          conjure-typescript                      
npm notice version:       0.0.0                                   
npm notice package size:  32.4 kB                                 
npm notice unpacked size: 151.4 kB                                
npm notice shasum:        b3b8881e531dd5e8129c82d538c67d9abe0fac62
npm notice integrity:     sha512-Yun85vRxLoIOC[...]3IBt9wDRdwHYw==
npm notice total files:   52                                      
```

==COMMIT_MSG==
Packages published to NPM now contain built lib code.
==COMMIT_MSG==

## Possible downsides?
Package size increases! 

