### PR TITLE
Revert "[improvement] Generate more lenient  enums"

### DIFF
--- a/src/commands/generate/__tests__/resources/test-cases/example-alias/alias/baz.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-alias/alias/baz.ts
@@ -1,0 +1,57 @@
+export interface IBaz_Str {
+    'str': string;
+    'type': "str";
+}
+
+export interface IBaz_Date {
+    'date': string;
+    'type': "date";
+}
+
+function isStr(obj: IBaz): obj is IBaz_Str {
+    return (obj.type === "str");
+}
+
+function str(obj: string): IBaz_Str {
+    return {
+        str: obj,
+        type: "str",
+    };
+}
+
+function isDate(obj: IBaz): obj is IBaz_Date {
+    return (obj.type === "date");
+}
+
+function date(obj: string): IBaz_Date {
+    return {
+        date: obj,
+        type: "date",
+    };
+}
+
+export type IBaz = IBaz_Str | IBaz_Date;
+
+export interface IBazVisitor<T> {
+    'str': (obj: string) => T;
+    'date': (obj: string) => T;
+    'unknown': (obj: IBaz) => T;
+}
+
+function visit<T>(obj: IBaz, visitor: IBazVisitor<T>): T {
+    if (isStr(obj)) {
+        return visitor.str(obj.str);
+    }
+    if (isDate(obj)) {
+        return visitor.date(obj.date);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IBaz = {
+    isStr: isStr,
+    str: str,
+    isDate: isDate,
+    date: date,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/test-cases/example-alias/alias/foo.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-alias/alias/foo.ts
@@ -1,0 +1,5 @@
+import * as IBaz from "./baz";
+
+export interface IFoo {
+    'myField': { [key: string]: IBaz.IBaz };
+}

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/enumExample.ts
@@ -2,10 +2,11 @@
  * This enumerates the numbers 1:2 also 100.
  * 
  */
-export type EnumExample = "ONE" | "TWO" | "ONE_HUNDRED";
-
-export const EnumExample = {
-    ONE: "ONE" as "ONE",
-    TWO: "TWO" as "TWO",
-    ONE_HUNDRED: "ONE_HUNDRED" as "ONE_HUNDRED"
-};
+export enum EnumExample {
+    ONE = "ONE",
+    TWO = "TWO",
+    /**
+     * Value of 100.
+     */
+    ONE_HUNDRED = "ONE_HUNDRED"
+}

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/simpleEnum.ts
@@ -1,5 +1,3 @@
-export type SimpleEnum = "VALUE";
-
-export const SimpleEnum = {
-    VALUE: "VALUE" as "VALUE"
-};
+export enum SimpleEnum {
+    VALUE = "VALUE"
+}

--- a/src/commands/generate/__tests__/resources/types/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/types/enumExample.ts
@@ -1,6 +1,4 @@
-export type EnumExample = "ONE" | "TWO";
-
-export const EnumExample = {
-    ONE: "ONE" as "ONE",
-    TWO: "TWO" as "TWO"
-};
+export enum EnumExample {
+    ONE = "ONE",
+    TWO = "TWO"
+}

--- a/src/commands/generate/__tests__/resources/types/enumWithDocs.ts
+++ b/src/commands/generate/__tests__/resources/types/enumWithDocs.ts
@@ -1,9 +1,10 @@
 /**
  * Some documentation
  */
-export type EnumWithDocs = "FOO" | "BAR";
-
-export const EnumWithDocs = {
-    FOO: "FOO" as "FOO",
-    BAR: "BAR" as "BAR"
-};
+export enum EnumWithDocs {
+    /**
+     * Some field documentation
+     */
+    FOO = "FOO",
+    BAR = "BAR"
+}

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -54,38 +54,19 @@ export function generateType(
  * export type EnumExample = "ONE" | "TWO";
  * export const EnumExample = { ONE: "ONE" as "ONE", TWO: "TWO" as "TWO" };
  * ```
- *
- * We do not use TypeScript Enums because they can not be assigned to an equivalent enum, making interop across
- * libraries more difficult
  */
 export async function generateEnum(definition: IEnumDefinition, simpleAst: SimpleAst): Promise<void> {
     const sourceFile = simpleAst.createSourceFile(definition.typeName);
 
-    const enumType = sourceFile.addTypeAlias({
+    sourceFile.addEnum({
+        docs: definition.docs != null ? [{ description: definition.docs }] : undefined,
         isExported: true,
+        members: definition.values.map(({ docs, value }) => ({
+            docs: docs != null ? [{ description: docs }] : undefined,
+            name: value,
+            value,
+        })),
         name: definition.typeName.name,
-        type: definition.values.map(({ value }) => doubleQuote(value)).join(" | "),
-    });
-    if (definition.docs != null) {
-        enumType.addJsDoc(definition.docs);
-    }
-
-    const variableStatement = sourceFile.addVariableStatement({
-        declarationKind: VariableDeclarationKind.Const,
-        declarations: [
-            {
-                initializer: "{}",
-                name: definition.typeName.name,
-            },
-        ],
-        isExported: true,
-    });
-    const objectLiteralExpr = variableStatement.getDeclarations()[0].getInitializer() as ObjectLiteralExpression;
-    definition.values.forEach(value => {
-        objectLiteralExpr.addPropertyAssignment({
-            initializer: `${doubleQuote(value.value)} as ${doubleQuote(value.value)}`,
-            name: value.value,
-        });
     });
 
     sourceFile.formatText();


### PR DESCRIPTION
Reverts palantir/conjure-typescript#85. We need to revert due to the unexpected compilation breaks that modifying the enum structure caused