### PR TITLE
[fix] Fix dumb error in batch script

### DIFF
--- a/bin/conjure-typescript.bat
+++ b/bin/conjure-typescript.bat
@@ -1,2 +1,2 @@
 @echo OFF
-node conjure-typescript.bat %*
+node %~dp0conjure-typescript %*

--- a/changelog/@unreleased/pr-97.v2.yml
+++ b/changelog/@unreleased/pr-97.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Windows batch script runs conjure typescript correctly now, by adding
+    the script path.
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/97


### PR DESCRIPTION
## Before this PR
I stupidly wrote the batch script wrong.

## After this PR
==COMMIT_MSG==
Windows batch script runs conjure typescript correctly now, by adding the script path.
==COMMIT_MSG==

Actually tested it in a real windows vm now.