### PR TITLE
Bd/fix path param ordering

### DIFF
--- a/changelog/@unreleased/path-param-ordering.v2.yml
+++ b/changelog/@unreleased/path-param-ordering.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix a problem with the generated code in the case where path params show up in different orders in the path template and the args block.
+  links:
+   - https://github.com/palantir/conjure-typescript/pull/100

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -1,0 +1,30 @@
+import { IHttpApiBridge, MediaType } from "conjure-client";
+
+export interface IOutOfOrderPathService {
+    foo(param1: string, param2: string): Promise<void>;
+}
+
+export class OutOfOrderPathService {
+    constructor(private bridge: IHttpApiBridge) {
+    }
+
+    public foo(param1: string, param2: string): Promise<void> {
+        return this.bridge.callEndpoint<void>({
+            data: undefined,
+            endpointName: "foo",
+            endpointPath: "/{param2}/{param1}",
+            headers: {
+            },
+            method: "GET",
+            pathArguments: [
+                param2,
+
+                param1,
+            ],
+            queryArguments: {
+            },
+            requestMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_JSON,
+        });
+    }
+}

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -261,6 +261,45 @@ describe("serviceGenerator", () => {
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/paramTypeService.ts");
     });
 
+    it("handles out of order path params", async () => {
+        await generateService(
+            {
+                endpoints: [
+                    {
+                        args: [
+                            {
+                                argName: "param1",
+                                markers: [],
+                                paramType: {
+                                    path: {},
+                                    type: "path",
+                                },
+                                type: stringType,
+                            },
+                            {
+                                argName: "param2",
+                                markers: [],
+                                paramType: {
+                                    path: {},
+                                    type: "path",
+                                },
+                                type: stringType,
+                            },
+                        ],
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/{param2}/{param1}",
+                        markers: [],
+                    },
+                ],
+                serviceName: { name: "OutOfOrderPathService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+        );
+        assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/outOfOrderPathService.ts");
+    });
+
     it("handles header auth-type", async () => {
         await generateService(
             {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -165,6 +165,13 @@ function generateEndpointBody(
         }
     });
 
+    const pathParamsFromPath = parsePathParamsFromPath(endpointDefinition.httpPath);
+    pathParamsFromPath.forEach(pathParam => {
+        if (pathArgNames.indexOf(pathParam) === -1) {
+            throw new Error("path parameter present in path template but not provided as endpoint param: " + pathParam);
+        }
+    });
+
     if (bodyArgs.length > 1) {
         throw Error("endpoint cannot have more than one body arg, found: " + bodyArgs.length);
     }
@@ -201,7 +208,7 @@ function generateEndpointBody(
             writer.writeLine(`method: "${endpointDefinition.httpMethod}",`);
 
             writer.write("pathArguments: [");
-            pathArgNames.forEach(pathArgName => writer.indent().writeLine(pathArgName + ","));
+            pathParamsFromPath.forEach(pathArgName => writer.indent().writeLine(pathArgName + ","));
             writer.writeLine("],");
 
             writer.write("queryArguments: {");
@@ -221,4 +228,14 @@ function mediaType(conjureType?: IType) {
         return "MediaType.APPLICATION_OCTET_STREAM";
     }
     return "MediaType.APPLICATION_JSON";
+}
+
+function parsePathParamsFromPath(httpPath: string): string[] {
+    // first fix up the path to remove any ':.+' stuff in path params
+    const fixedPath = httpPath.replace(/{(.*):[^}]*}/, "{$1}");
+    // follow-up by just pulling out any path segment with a starting '{' and trailing '}'
+    return fixedPath
+        .split("/")
+        .filter(segment => segment.startsWith("{") && segment.endsWith("}"))
+        .map(segment => segment.slice(1, -1));
 }

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -166,11 +166,6 @@ function generateEndpointBody(
     });
 
     const pathParamsFromPath = parsePathParamsFromPath(endpointDefinition.httpPath);
-    pathParamsFromPath.forEach(pathParam => {
-        if (pathArgNames.indexOf(pathParam) === -1) {
-            throw new Error("path parameter present in path template but not provided as endpoint param: " + pathParam);
-        }
-    });
 
     if (bodyArgs.length > 1) {
         throw Error("endpoint cannot have more than one body arg, found: " + bodyArgs.length);


### PR DESCRIPTION
Fixes #99 

## Possible downsides?
Fix isn't super pretty.

Part of me wonders whether this should actually end up being a conjure-ir spec change - whereby we assert in the IR the ordering matches up.

I'm also not super happy with the munging I have to do to make the special `{thing:.+}` style path params work. Such path parameters don't show up in the conjure docs (at least not in https://palantir.github.io/conjure/#/docs/spec/conjure_definitions?id=path-parameters) but are part of the test suite.