### PR TITLE
Conjure binary type is implemented as Blob type

### DIFF
--- a/changelog/@unreleased/binary-as-blob.v2.yml
+++ b/changelog/@unreleased/binary-as-blob.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure binary type is implemented as Blob type
+  links:
+   - https://github.com/palantir/conjure-typescript/pull/102

--- a/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
@@ -1,9 +1,9 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
 export interface IEteBinaryService {
-    postBinary(body: any): Promise<any>;
-    getOptionalBinaryPresent(): Promise<any | null>;
-    getOptionalBinaryEmpty(): Promise<any | null>;
+    postBinary(body: Blob): Promise<Blob>;
+    getOptionalBinaryPresent(): Promise<Blob | null>;
+    getOptionalBinaryEmpty(): Promise<Blob | null>;
     /**
      * Throws an exception after partially writing a binary response.
      */
@@ -14,8 +14,8 @@ export class EteBinaryService {
     constructor(private bridge: IHttpApiBridge) {
     }
 
-    public postBinary(body: any): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+    public postBinary(body: Blob): Promise<Blob> {
+        return this.bridge.callEndpoint<Blob>({
             data: body,
             endpointName: "postBinary",
             endpointPath: "/binary",
@@ -31,8 +31,8 @@ export class EteBinaryService {
         });
     }
 
-    public getOptionalBinaryPresent(): Promise<any | null> {
-        return this.bridge.callEndpoint<any | null>({
+    public getOptionalBinaryPresent(): Promise<Blob | null> {
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "getOptionalBinaryPresent",
             endpointPath: "/binary/optional/present",
@@ -48,8 +48,8 @@ export class EteBinaryService {
         });
     }
 
-    public getOptionalBinaryEmpty(): Promise<any | null> {
-        return this.bridge.callEndpoint<any | null>({
+    public getOptionalBinaryEmpty(): Promise<Blob | null> {
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "getOptionalBinaryEmpty",
             endpointPath: "/binary/optional/empty",
@@ -66,7 +66,7 @@ export class EteBinaryService {
     }
 
     public getBinaryFailure(numBytes: number): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getBinaryFailure",
             endpointPath: "/binary/failure",

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': any;
+    'binary': Blob;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
@@ -1,3 +1,3 @@
 export interface IOptionalExample {
-    'item'?: any | null;
+    'item'?: Blob | null;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -96,7 +96,7 @@ export class TestService {
     }
 
     public getRawData(datasetRid: string): Promise<Blob> {
-        return this.bridge.callEndpoint<any>({
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw",
@@ -114,7 +114,7 @@ export class TestService {
     }
 
     public getAliasedRawData(datasetRid: string): Promise<Blob> {
-        return this.bridge.callEndpoint<any>({
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getAliasedRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-aliased",
@@ -132,7 +132,7 @@ export class TestService {
     }
 
     public maybeGetRawData(datasetRid: string): Promise<Blob | null> {
-        return this.bridge.callEndpoint<any | null>({
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "maybeGetRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-maybe",
@@ -167,7 +167,7 @@ export class TestService {
         });
     }
 
-    public uploadRawData(input: any): Promise<void> {
+    public uploadRawData(input: Blob): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadRawData",
@@ -184,7 +184,7 @@ export class TestService {
         });
     }
 
-    public uploadAliasedRawData(input: any): Promise<void> {
+    public uploadAliasedRawData(input: Blob): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadAliasedRawData",

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -15,12 +15,12 @@ export interface ITestService {
     getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }>;
     createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
     getDataset(datasetRid: string): Promise<IDataset | null>;
-    getRawData(datasetRid: string): Promise<any>;
-    getAliasedRawData(datasetRid: string): Promise<any>;
-    maybeGetRawData(datasetRid: string): Promise<any | null>;
+    getRawData(datasetRid: string): Promise<Blob>;
+    getAliasedRawData(datasetRid: string): Promise<Blob>;
+    maybeGetRawData(datasetRid: string): Promise<Blob | null>;
     getAliasedString(datasetRid: string): Promise<string>;
-    uploadRawData(input: any): Promise<void>;
-    uploadAliasedRawData(input: any): Promise<void>;
+    uploadRawData(input: Blob): Promise<void>;
+    uploadAliasedRawData(input: Blob): Promise<void>;
     getBranches(datasetRid: string): Promise<Array<string>>;
     /**
      * Gets all branches of this dataset.
@@ -95,7 +95,7 @@ export class TestService {
         });
     }
 
-    public getRawData(datasetRid: string): Promise<any> {
+    public getRawData(datasetRid: string): Promise<Blob> {
         return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "getRawData",
@@ -113,7 +113,7 @@ export class TestService {
         });
     }
 
-    public getAliasedRawData(datasetRid: string): Promise<any> {
+    public getAliasedRawData(datasetRid: string): Promise<Blob> {
         return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "getAliasedRawData",
@@ -131,7 +131,7 @@ export class TestService {
         });
     }
 
-    public maybeGetRawData(datasetRid: string): Promise<any | null> {
+    public maybeGetRawData(datasetRid: string): Promise<Blob | null> {
         return this.bridge.callEndpoint<any | null>({
             data: undefined,
             endpointName: "maybeGetRawData",

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': any;
+    'binary': Blob;
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -132,7 +132,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(): Promise<any>;");
+        expect(contents).toContain("foo(): Promise<Blob>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_JSON`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });
@@ -164,7 +164,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(body: any): Promise<any>;");
+        expect(contents).toContain("foo(body: any): Promise<Blob>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_OCTET_STREAM`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -164,7 +164,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(body: any): Promise<Blob>;");
+        expect(contents).toContain("foo(body: Blob): Promise<Blob>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_OCTET_STREAM`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });

--- a/src/commands/generate/__tests__/tsTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsTypeVisitorTest.ts
@@ -58,7 +58,7 @@ describe("TsTypeVisitor", () => {
         expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
         expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
         expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("any");
+        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("Blob");
         expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
         expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
         expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");

--- a/src/commands/generate/tsTypeVisitor.ts
+++ b/src/commands/generate/tsTypeVisitor.ts
@@ -45,6 +45,7 @@ export class TsTypeVisitor implements ITypeVisitor<string> {
             case PrimitiveType.SAFELONG:
                 return "number";
             case PrimitiveType.BINARY:
+                return "Blob";
             case PrimitiveType.ANY:
                 return "any";
             case PrimitiveType.BOOLEAN:


### PR DESCRIPTION
## Before this PR
having endpoint that returns `binary` in conjure results in unexpected generated api that has return type of `Promise<any>`. However, conjure-typescript-runtime library will return Blob https://developer.mozilla.org/en-US/docs/Web/API/Body/blob

Happy to consider changing Blob to ArrayBuffer which would better suit my needs overall, however, that would also require changing `conjure-typescript-runtime`

## After this PR
==COMMIT_MSG==
conjure binary type is explicitly converted to Blob type to match conjure-typescript-runtime
==COMMIT_MSG==

## Possible downsides?
Given that this is the runtime type the potential breaks should be nonexistent but there's still possibility where some implicit casts will have to become explicit.

