### PR TITLE
Conjure binary type is any as previous change didn't account for difference in top level and nested binary types

### DIFF
--- a/changelog/@unreleased/binary-as-blob.v2.yml
+++ b/changelog/@unreleased/binary-as-blob.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Conjure binary type is any as previous change didn't account for difference in top level and nested binary types
+  links:
+   - https://github.com/palantir/conjure-typescript/pull/104

--- a/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
@@ -1,9 +1,9 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
 export interface IEteBinaryService {
-    postBinary(body: Blob): Promise<Blob>;
-    getOptionalBinaryPresent(): Promise<Blob | null>;
-    getOptionalBinaryEmpty(): Promise<Blob | null>;
+    postBinary(body: any): Promise<any>;
+    getOptionalBinaryPresent(): Promise<any | null>;
+    getOptionalBinaryEmpty(): Promise<any | null>;
     /**
      * Throws an exception after partially writing a binary response.
      */
@@ -14,8 +14,8 @@ export class EteBinaryService {
     constructor(private bridge: IHttpApiBridge) {
     }
 
-    public postBinary(body: Blob): Promise<Blob> {
-        return this.bridge.callEndpoint<Blob>({
+    public postBinary(body: any): Promise<any> {
+        return this.bridge.callEndpoint<any>({
             data: body,
             endpointName: "postBinary",
             endpointPath: "/binary",
@@ -31,8 +31,8 @@ export class EteBinaryService {
         });
     }
 
-    public getOptionalBinaryPresent(): Promise<Blob | null> {
-        return this.bridge.callEndpoint<Blob | null>({
+    public getOptionalBinaryPresent(): Promise<any | null> {
+        return this.bridge.callEndpoint<any | null>({
             data: undefined,
             endpointName: "getOptionalBinaryPresent",
             endpointPath: "/binary/optional/present",
@@ -48,8 +48,8 @@ export class EteBinaryService {
         });
     }
 
-    public getOptionalBinaryEmpty(): Promise<Blob | null> {
-        return this.bridge.callEndpoint<Blob | null>({
+    public getOptionalBinaryEmpty(): Promise<any | null> {
+        return this.bridge.callEndpoint<any | null>({
             data: undefined,
             endpointName: "getOptionalBinaryEmpty",
             endpointPath: "/binary/optional/empty",
@@ -66,7 +66,7 @@ export class EteBinaryService {
     }
 
     public getBinaryFailure(numBytes: number): Promise<any> {
-        return this.bridge.callEndpoint<Blob>({
+        return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "getBinaryFailure",
             endpointPath: "/binary/failure",

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': Blob;
+    'binary': any;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
@@ -1,3 +1,3 @@
 export interface IOptionalExample {
-    'item'?: Blob | null;
+    'item'?: any | null;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -15,12 +15,12 @@ export interface ITestService {
     getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }>;
     createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
     getDataset(datasetRid: string): Promise<IDataset | null>;
-    getRawData(datasetRid: string): Promise<Blob>;
-    getAliasedRawData(datasetRid: string): Promise<Blob>;
-    maybeGetRawData(datasetRid: string): Promise<Blob | null>;
+    getRawData(datasetRid: string): Promise<any>;
+    getAliasedRawData(datasetRid: string): Promise<any>;
+    maybeGetRawData(datasetRid: string): Promise<any | null>;
     getAliasedString(datasetRid: string): Promise<string>;
-    uploadRawData(input: Blob): Promise<void>;
-    uploadAliasedRawData(input: Blob): Promise<void>;
+    uploadRawData(input: any): Promise<void>;
+    uploadAliasedRawData(input: any): Promise<void>;
     getBranches(datasetRid: string): Promise<Array<string>>;
     /**
      * Gets all branches of this dataset.
@@ -95,8 +95,8 @@ export class TestService {
         });
     }
 
-    public getRawData(datasetRid: string): Promise<Blob> {
-        return this.bridge.callEndpoint<Blob>({
+    public getRawData(datasetRid: string): Promise<any> {
+        return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "getRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw",
@@ -113,8 +113,8 @@ export class TestService {
         });
     }
 
-    public getAliasedRawData(datasetRid: string): Promise<Blob> {
-        return this.bridge.callEndpoint<Blob>({
+    public getAliasedRawData(datasetRid: string): Promise<any> {
+        return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "getAliasedRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-aliased",
@@ -131,8 +131,8 @@ export class TestService {
         });
     }
 
-    public maybeGetRawData(datasetRid: string): Promise<Blob | null> {
-        return this.bridge.callEndpoint<Blob | null>({
+    public maybeGetRawData(datasetRid: string): Promise<any | null> {
+        return this.bridge.callEndpoint<any | null>({
             data: undefined,
             endpointName: "maybeGetRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-maybe",
@@ -167,7 +167,7 @@ export class TestService {
         });
     }
 
-    public uploadRawData(input: Blob): Promise<void> {
+    public uploadRawData(input: any): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadRawData",
@@ -184,7 +184,7 @@ export class TestService {
         });
     }
 
-    public uploadAliasedRawData(input: Blob): Promise<void> {
+    public uploadAliasedRawData(input: any): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadAliasedRawData",

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': Blob;
+    'binary': any;
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -132,7 +132,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(): Promise<Blob>;");
+        expect(contents).toContain("foo(): Promise<any>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_JSON`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });
@@ -164,7 +164,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(body: Blob): Promise<Blob>;");
+        expect(contents).toContain("foo(body: any): Promise<any>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_OCTET_STREAM`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });

--- a/src/commands/generate/__tests__/tsTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsTypeVisitorTest.ts
@@ -58,7 +58,7 @@ describe("TsTypeVisitor", () => {
         expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
         expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
         expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("Blob");
+        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("any");
         expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
         expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
         expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");

--- a/src/commands/generate/tsTypeVisitor.ts
+++ b/src/commands/generate/tsTypeVisitor.ts
@@ -45,7 +45,6 @@ export class TsTypeVisitor implements ITypeVisitor<string> {
             case PrimitiveType.SAFELONG:
                 return "number";
             case PrimitiveType.BINARY:
-                return "Blob";
             case PrimitiveType.ANY:
                 return "any";
             case PrimitiveType.BOOLEAN:


### PR DESCRIPTION
## Before this PR
#103 is an issue

## After this PR
==COMMIT_MSG==
Binary conjure type is encoded as any. Since top level and nested binary types have to behave differently
==COMMIT_MSG==
fixes #103
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

