### PR TITLE
Top level binary type is generated as Blob type with correct response and request media types

### DIFF
--- a/changelog/@unreleased/binary-as-blob.v2.yml
+++ b/changelog/@unreleased/binary-as-blob.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Top level binary type is generated as Blob type with correct response and request media types
+  links:
+   - https://github.com/palantir/conjure-typescript/pull/104

--- a/scripts/download-conjure-core.sh
+++ b/scripts/download-conjure-core.sh
@@ -10,4 +10,4 @@ mkdir -p build/downloads
 curl -L "https://palantir.bintray.com/releases/com/palantir/conjure/conjure/${VERSION}/${ARTIFACT_NAME}.tgz" -o "$DOWNLOAD_OUTPUT"
 
 tar xf "$DOWNLOAD_OUTPUT" -C build
-mv "build/$ARTIFACT_NAME" build/conjure
+[ ! -d "build/conjure/$ARTIFACT_NAME" ] && mv "build/$ARTIFACT_NAME" build/conjure || true

--- a/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
@@ -56,7 +56,7 @@ describe("testMediaTypeGenerator", () => {
         ]),
     );
 
-    it("returns primitive types", () => {
+    it("returns correct media type for primitives", () => {
         expect(visitor.primitive(PrimitiveType.STRING)).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("MediaType.APPLICATION_JSON");
@@ -75,35 +75,35 @@ describe("testMediaTypeGenerator", () => {
         expect(tsType).toThrowError(/unknown reference type/);
     });
 
-    it("returns reference type", () => {
+    it("returns application/json for reference type", () => {
         expect(visitor.reference(objectName)).toEqual("MediaType.APPLICATION_JSON");
     });
 
-    it("follows alias reference", () => {
+    it("follows alias reference for media type", () => {
         expect(visitor.reference(aliasName)).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.reference(binaryAliasName)).toEqual("MediaType.APPLICATION_OCTET_STREAM");
     });
 
-    it("returns enum reference without I prefix", () => {
+    it("returns application/json for enum", () => {
         expect(visitor.reference(enumName)).toEqual("MediaType.APPLICATION_JSON");
     });
 
-    it("returns optional type", () => {
+    it("follows optional element type for media type", () => {
         expect(visitor.optional({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_OCTET_STREAM");
     });
 
-    it("returns list type", () => {
+    it("returns application/json for list type", () => {
         expect(visitor.list({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.list({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
     });
 
-    it("returns set type", () => {
+    it("returns application/json for set type", () => {
         expect(visitor.set({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
         expect(visitor.set({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
     });
 
-    it("returns map type", () => {
+    it("returns application/json for map type", () => {
         expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
             "MediaType.APPLICATION_JSON",
         );
@@ -111,20 +111,12 @@ describe("testMediaTypeGenerator", () => {
             "MediaType.APPLICATION_JSON",
         );
     });
-    it("follows primitive external fallback", () => {
+
+    it("returns application/json for external types", () => {
         const unusedTypeName = { name: "Unused", package: "" };
         const externalType = {
             externalReference: unusedTypeName,
             fallback: IType.primitive(PrimitiveType.ANY),
-        };
-        expect(visitor.external(externalType)).toEqual("MediaType.APPLICATION_JSON");
-    });
-
-    it("follows complex external fallback", () => {
-        const unusedTypeName = { name: "Unused", package: "" };
-        const externalType = {
-            externalReference: unusedTypeName,
-            fallback: IType.list({ itemType: objectReference }),
         };
         expect(visitor.external(externalType)).toEqual("MediaType.APPLICATION_JSON");
     });

--- a/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
+import { MediaTypeVisitor } from "../mediaTypeVisitor";
+import { createHashableTypeName } from "../utils";
+
+describe("testMediaTypeGenerator", () => {
+    const objectName = { name: "Object", package: "" };
+    const objectReference = IType.reference(objectName);
+    const object = ITypeDefinition.object({
+        fields: [],
+        typeName: objectName,
+    });
+
+    const aliasName = { name: "Alias", package: "" };
+    const aliasReference = IType.reference(aliasName);
+    const alias = ITypeDefinition.alias({
+        alias: { primitive: PrimitiveType.STRING, type: "primitive" },
+        typeName: aliasName,
+    });
+
+    const binaryAliasName = { name: "BinaryAlias", package: "" };
+    const binaryAliasReference = IType.reference(binaryAliasName);
+    const binaryAlias = ITypeDefinition.alias({
+        alias: { primitive: PrimitiveType.BINARY, type: "primitive" },
+        typeName: binaryAliasName,
+    });
+
+    const enumName = { name: "Enum", package: "" };
+    const enumType = ITypeDefinition.enum_({
+        typeName: enumName,
+        values: [{ value: "FOO" }],
+    });
+
+    const visitor = new MediaTypeVisitor(
+        new Map<string, ITypeDefinition>([
+            [createHashableTypeName(objectName), object],
+            [createHashableTypeName(aliasName), alias],
+            [createHashableTypeName(binaryAliasName), binaryAlias],
+            [createHashableTypeName(enumName), enumType],
+        ]),
+    );
+
+    it("returns primitive types", () => {
+        expect(visitor.primitive(PrimitiveType.STRING)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("MediaType.APPLICATION_OCTET_STREAM");
+        expect(visitor.primitive(PrimitiveType.ANY)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.RID)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.UUID)).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("produces error for unknown reference", () => {
+        const tsType = () => new MediaTypeVisitor(new Map<string, ITypeDefinition>()).reference(objectName);
+        expect(tsType).toThrowError(/unknown reference type/);
+    });
+
+    it("returns reference type", () => {
+        expect(visitor.reference(objectName)).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("follows alias reference", () => {
+        expect(visitor.reference(aliasName)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.reference(binaryAliasName)).toEqual("MediaType.APPLICATION_OCTET_STREAM");
+    });
+
+    it("returns enum reference without I prefix", () => {
+        expect(visitor.reference(enumName)).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("returns optional type", () => {
+        expect(visitor.optional({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_OCTET_STREAM");
+    });
+
+    it("returns list type", () => {
+        expect(visitor.list({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.list({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("returns set type", () => {
+        expect(visitor.set({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.set({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("returns map type", () => {
+        expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
+            "MediaType.APPLICATION_JSON",
+        );
+        expect(visitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
+            "MediaType.APPLICATION_JSON",
+        );
+    });
+    it("follows primitive external fallback", () => {
+        const unusedTypeName = { name: "Unused", package: "" };
+        const externalType = {
+            externalReference: unusedTypeName,
+            fallback: IType.primitive(PrimitiveType.ANY),
+        };
+        expect(visitor.external(externalType)).toEqual("MediaType.APPLICATION_JSON");
+    });
+
+    it("follows complex external fallback", () => {
+        const unusedTypeName = { name: "Unused", package: "" };
+        const externalType = {
+            externalReference: unusedTypeName,
+            fallback: IType.list({ itemType: objectReference }),
+        };
+        expect(visitor.external(externalType)).toEqual("MediaType.APPLICATION_JSON");
+    });
+});

--- a/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/ete-binary/product/eteBinaryService.ts
@@ -1,9 +1,9 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
 export interface IEteBinaryService {
-    postBinary(body: any): Promise<any>;
-    getOptionalBinaryPresent(): Promise<any | null>;
-    getOptionalBinaryEmpty(): Promise<any | null>;
+    postBinary(body: Blob): Promise<Blob>;
+    getOptionalBinaryPresent(): Promise<Blob | null>;
+    getOptionalBinaryEmpty(): Promise<Blob | null>;
     /**
      * Throws an exception after partially writing a binary response.
      */
@@ -14,8 +14,8 @@ export class EteBinaryService {
     constructor(private bridge: IHttpApiBridge) {
     }
 
-    public postBinary(body: any): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+    public postBinary(body: Blob): Promise<Blob> {
+        return this.bridge.callEndpoint<Blob>({
             data: body,
             endpointName: "postBinary",
             endpointPath: "/binary",
@@ -31,8 +31,8 @@ export class EteBinaryService {
         });
     }
 
-    public getOptionalBinaryPresent(): Promise<any | null> {
-        return this.bridge.callEndpoint<any | null>({
+    public getOptionalBinaryPresent(): Promise<Blob | null> {
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "getOptionalBinaryPresent",
             endpointPath: "/binary/optional/present",
@@ -44,12 +44,12 @@ export class EteBinaryService {
             queryArguments: {
             },
             requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
         });
     }
 
-    public getOptionalBinaryEmpty(): Promise<any | null> {
-        return this.bridge.callEndpoint<any | null>({
+    public getOptionalBinaryEmpty(): Promise<Blob | null> {
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "getOptionalBinaryEmpty",
             endpointPath: "/binary/optional/empty",
@@ -61,12 +61,12 @@ export class EteBinaryService {
             queryArguments: {
             },
             requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
         });
     }
 
-    public getBinaryFailure(numBytes: number): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+    public getBinaryFailure(numBytes: number): Promise<Blob> {
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getBinaryFailure",
             endpointPath: "/binary/failure",

--- a/src/commands/generate/__tests__/resources/test-cases/ete-service/product/eteService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/ete-service/product/eteService.ts
@@ -202,7 +202,7 @@ export class EteService {
         });
     }
 
-    public binary(): Promise<any> {
+    public binary(): Promise<Blob> {
         return this.bridge.callEndpoint<any>({
             data: undefined,
             endpointName: "binary",

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': any;
+    'binary': string;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-binary-types/binary/optionalExample.ts
@@ -1,3 +1,3 @@
 export interface IOptionalExample {
-    'item'?: any | null;
+    'item'?: string | null;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -15,12 +15,12 @@ export interface ITestService {
     getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }>;
     createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
     getDataset(datasetRid: string): Promise<IDataset | null>;
-    getRawData(datasetRid: string): Promise<any>;
-    getAliasedRawData(datasetRid: string): Promise<any>;
-    maybeGetRawData(datasetRid: string): Promise<any | null>;
+    getRawData(datasetRid: string): Promise<Blob>;
+    getAliasedRawData(datasetRid: string): Promise<Blob>;
+    maybeGetRawData(datasetRid: string): Promise<Blob | null>;
     getAliasedString(datasetRid: string): Promise<string>;
-    uploadRawData(input: any): Promise<void>;
-    uploadAliasedRawData(input: any): Promise<void>;
+    uploadRawData(input: Blob): Promise<void>;
+    uploadAliasedRawData(input: Blob): Promise<void>;
     getBranches(datasetRid: string): Promise<Array<string>>;
     /**
      * Gets all branches of this dataset.
@@ -95,8 +95,8 @@ export class TestService {
         });
     }
 
-    public getRawData(datasetRid: string): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+    public getRawData(datasetRid: string): Promise<Blob> {
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw",
@@ -113,8 +113,8 @@ export class TestService {
         });
     }
 
-    public getAliasedRawData(datasetRid: string): Promise<any> {
-        return this.bridge.callEndpoint<any>({
+    public getAliasedRawData(datasetRid: string): Promise<Blob> {
+        return this.bridge.callEndpoint<Blob>({
             data: undefined,
             endpointName: "getAliasedRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-aliased",
@@ -127,12 +127,12 @@ export class TestService {
             queryArguments: {
             },
             requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
         });
     }
 
-    public maybeGetRawData(datasetRid: string): Promise<any | null> {
-        return this.bridge.callEndpoint<any | null>({
+    public maybeGetRawData(datasetRid: string): Promise<Blob | null> {
+        return this.bridge.callEndpoint<Blob | null>({
             data: undefined,
             endpointName: "maybeGetRawData",
             endpointPath: "/catalog/datasets/{datasetRid}/raw-maybe",
@@ -145,7 +145,7 @@ export class TestService {
             queryArguments: {
             },
             requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
         });
     }
 
@@ -167,7 +167,7 @@ export class TestService {
         });
     }
 
-    public uploadRawData(input: any): Promise<void> {
+    public uploadRawData(input: Blob): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadRawData",
@@ -184,7 +184,7 @@ export class TestService {
         });
     }
 
-    public uploadAliasedRawData(input: any): Promise<void> {
+    public uploadAliasedRawData(input: Blob): Promise<void> {
         return this.bridge.callEndpoint<void>({
             data: input,
             endpointName: "uploadAliasedRawData",
@@ -196,7 +196,7 @@ export class TestService {
             ],
             queryArguments: {
             },
-            requestMediaType: MediaType.APPLICATION_JSON,
+            requestMediaType: MediaType.APPLICATION_OCTET_STREAM,
             responseMediaType: MediaType.APPLICATION_JSON,
         });
     }

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': any;
+    'binary': string;
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -132,7 +132,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(): Promise<any>;");
+        expect(contents).toContain("foo(): Promise<Blob>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_JSON`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });
@@ -164,7 +164,7 @@ describe("serviceGenerator", () => {
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain("foo(body: any): Promise<any>;");
+        expect(contents).toContain("foo(body: Blob): Promise<Blob>;");
         expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_OCTET_STREAM`);
         expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
     });

--- a/src/commands/generate/errorGenerator.ts
+++ b/src/commands/generate/errorGenerator.ts
@@ -30,7 +30,7 @@ export function generateError(
     const sourceFile = simpleAst.createSourceFile(definition.errorName);
     const interfaceName = "I" + definition.errorName.name;
     const errorName = `${definition.namespace}:${definition.errorName.name}`;
-    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.errorName);
+    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.errorName, false);
     const importsVisitor = new ImportsVisitor(knownTypes, definition.errorName);
     const imports: ImportDeclarationStructure[] = [];
 

--- a/src/commands/generate/imports.ts
+++ b/src/commands/generate/imports.ts
@@ -35,7 +35,7 @@ import { createHashableTypeName } from "./utils";
 export class ImportsVisitor implements ITypeVisitor<ImportDeclarationStructure[]> {
     private tsTypeVisitor: TsTypeVisitor;
     constructor(private knownTypes: Map<string, ITypeDefinition>, private currType: ITypeName) {
-        this.tsTypeVisitor = new TsTypeVisitor(knownTypes, currType);
+        this.tsTypeVisitor = new TsTypeVisitor(knownTypes, currType, false);
     }
 
     public primitive = (_: PrimitiveType): ImportDeclarationStructure[] => [];

--- a/src/commands/generate/mediaTypeVisitor.ts
+++ b/src/commands/generate/mediaTypeVisitor.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    IExternalReference,
+    IListType,
+    IMapType,
+    IOptionalType,
+    ISetType,
+    IType,
+    ITypeDefinition,
+    ITypeName,
+    ITypeVisitor,
+    PrimitiveType,
+} from "conjure-api";
+import { createHashableTypeName } from "./utils";
+
+export class MediaTypeVisitor implements ITypeVisitor<string> {
+    constructor(private knownTypes: Map<string, ITypeDefinition>) {}
+
+    public external = (_: IExternalReference): string => {
+        return "MediaType.APPLICATION_JSON";
+    };
+    public list = (_: IListType): string => {
+        return "MediaType.APPLICATION_JSON";
+    };
+    public map = (_: IMapType): string => {
+        return "MediaType.APPLICATION_JSON";
+    };
+    public optional = (obj: IOptionalType): string => {
+        return IType.visit(obj.itemType, this);
+    };
+    public primitive = (obj: PrimitiveType): string => {
+        switch (obj) {
+            case PrimitiveType.STRING:
+            case PrimitiveType.DATETIME:
+            case PrimitiveType.RID:
+            case PrimitiveType.BEARERTOKEN:
+            case PrimitiveType.DOUBLE:
+            case PrimitiveType.INTEGER:
+            case PrimitiveType.SAFELONG:
+            case PrimitiveType.ANY:
+            case PrimitiveType.BOOLEAN:
+            case PrimitiveType.UUID:
+                return "MediaType.APPLICATION_JSON";
+            case PrimitiveType.BINARY:
+                return "MediaType.APPLICATION_OCTET_STREAM";
+            default:
+                throw new Error("unknown primitive type");
+        }
+    };
+    public reference = (obj: ITypeName): string => {
+        const typeDefinition = this.knownTypes.get(createHashableTypeName(obj));
+        if (typeDefinition == null) {
+            throw new Error(`unknown reference type. package: '${obj.package}', name: '${obj.name}'`);
+        } else if (ITypeDefinition.isAlias(typeDefinition)) {
+            return IType.visit(typeDefinition.alias.alias, this);
+        }
+        return "MediaType.APPLICATION_JSON";
+    };
+    public set = (_: ISetType): string => {
+        return "MediaType.APPLICATION_JSON";
+    };
+    public unknown = (_: IType): string => {
+        return "MediaType.APPLICATION_JSON";
+    };
+}

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -24,7 +24,7 @@ import {
     IServiceDefinition,
     IType,
     ITypeDefinition,
-    PrimitiveType,
+    ITypeVisitor,
 } from "conjure-api";
 import {
     CodeBlockWriter,
@@ -34,6 +34,7 @@ import {
     Scope,
 } from "ts-simple-ast";
 import { ImportsVisitor, sortImports } from "./imports";
+import { MediaTypeVisitor } from "./mediaTypeVisitor";
 import { SimpleAst } from "./simpleAst";
 import { StringConversionTypeVisitor } from "./stringConversionTypeVisitor";
 import { TsTypeVisitor } from "./tsTypeVisitor";
@@ -59,8 +60,9 @@ export function generateService(
     simpleAst: SimpleAst,
 ): Promise<void> {
     const sourceFile = simpleAst.createSourceFile(definition.serviceName);
-    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.serviceName);
+    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.serviceName, true);
     const importsVisitor = new ImportsVisitor(knownTypes, definition.serviceName);
+    const mediaTypeVisitor = new MediaTypeVisitor(knownTypes);
 
     const endpointSignatures: MethodDeclarationStructure[] = [];
     const endpointImplementations: MethodDeclarationStructure[] = [];
@@ -100,7 +102,7 @@ export function generateService(
         endpointSignatures.push(signature);
 
         endpointImplementations.push({
-            bodyText: generateEndpointBody(endpointDefinition, returnTsType, endpointDefinition.returns || undefined),
+            bodyText: generateEndpointBody(endpointDefinition, returnTsType, mediaTypeVisitor),
             name: endpointDefinition.endpointName,
             parameters,
             returnType: `Promise<${returnTsType}>`,
@@ -146,18 +148,15 @@ export function generateService(
 function generateEndpointBody(
     endpointDefinition: IEndpointDefinition,
     returnTsType: string,
-    returnType?: IType,
+    mediaTypeVisitor: ITypeVisitor<string>,
 ): (writer: CodeBlockWriter) => void {
     const bodyArgs: IArgumentDefinition[] = [];
-    const pathArgNames: string[] = [];
     const headerArgs: IArgumentDefinition[] = [];
     const queryArgs: IArgumentDefinition[] = [];
 
     endpointDefinition.args.forEach(argDefinition => {
         if (IParameterType.isBody(argDefinition.paramType)) {
             bodyArgs.push(argDefinition);
-        } else if (IParameterType.isPath(argDefinition.paramType)) {
-            pathArgNames.push(argDefinition.argName);
         } else if (IParameterType.isHeader(argDefinition.paramType)) {
             headerArgs.push(argDefinition);
         } else if (IParameterType.isQuery(argDefinition.paramType)) {
@@ -171,7 +170,8 @@ function generateEndpointBody(
         throw Error("endpoint cannot have more than one body arg, found: " + bodyArgs.length);
     }
     const data = bodyArgs.length === 0 ? "undefined" : bodyArgs[0].argName;
-    const bodyType = bodyArgs.length === 0 ? undefined : bodyArgs[0].type;
+    const requestMediaType =
+        bodyArgs.length === 0 ? "MediaType.APPLICATION_JSON" : IType.visit(bodyArgs[0].type, mediaTypeVisitor);
     const formattedHeaderArgs = headerArgs.map(argDefinition => {
         const paramId = (argDefinition.paramType as IParameterType_Header).header.paramId!;
         if (paramId == null) {
@@ -187,8 +187,10 @@ function generateEndpointBody(
         }
         return `"${paramId}": ${argDefinition.argName},`;
     });
-    const requestMediaType = mediaType(bodyType);
-    const responseMediaType = mediaType(returnType);
+    const responseMediaType =
+        endpointDefinition.returns !== undefined && endpointDefinition.returns !== null
+            ? IType.visit(endpointDefinition.returns, mediaTypeVisitor)
+            : "MediaType.APPLICATION_JSON";
 
     return writer => {
         writer.write(`return this.${BRIDGE}.callEndpoint<${returnTsType}>(`).inlineBlock(() => {
@@ -216,13 +218,6 @@ function generateEndpointBody(
         });
         writer.write(");");
     };
-}
-
-function mediaType(conjureType?: IType) {
-    if (conjureType != null && IType.isPrimitive(conjureType) && conjureType.primitive === PrimitiveType.BINARY) {
-        return "MediaType.APPLICATION_OCTET_STREAM";
-    }
-    return "MediaType.APPLICATION_JSON";
 }
 
 function parsePathParamsFromPath(httpPath: string): string[] {

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -88,7 +88,7 @@ export async function generateObject(
     knownTypes: Map<string, ITypeDefinition>,
     simpleAst: SimpleAst,
 ) {
-    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.typeName);
+    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.typeName, false);
     const importsVisitor = new ImportsVisitor(knownTypes, definition.typeName);
     const properties: PropertySignatureStructure[] = [];
     const imports: ImportDeclarationStructure[] = [];
@@ -203,7 +203,7 @@ function processUnionMembers(
     definition: IUnionDefinition,
     knownTypes: Map<string, ITypeDefinition>,
 ) {
-    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.typeName);
+    const tsTypeVisitor = new TsTypeVisitor(knownTypes, definition.typeName, false);
     const importsVisitor = new ImportsVisitor(knownTypes, definition.typeName);
 
     const imports: ImportDeclarationStructure[] = [];


### PR DESCRIPTION
## Before this PR
This is a complete version of change done in #102 which had to be reverted due to naive handling of nested binary types

## After this PR
==COMMIT_MSG==
conjure-typescript generated interfaces correctly declare binary as either string or Blob depending on the location in the definition. The media types for response and request types are set to application/octet-stream for anything that is of Blob type in the service interface
==COMMIT_MSG==

## Possible downsides?
There could be cases that we don't handle since the conjure-verification framework doesn't have cases for binary type interop
