### PR TITLE
No human +1 for dependabot PRs

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -9,7 +9,7 @@ policy:
       - fixing excavator
       - excavator only touched baseline, circle, gradle files, godel files, docker-compose-rule config or versions.props
       - excavator only touched package.json and lock files
-      - excavator only touched config files
+      - bots updated package.json and lock files
   disapproval:
     requires:
       organizations: [ "palantir" ]
@@ -89,12 +89,14 @@ approval_rules:
           - "^\\..*.yml$"
           - "^\\.github/.*$"
 
-  - name: excavator only touched package.json and lock files
+  - name: bots updated package.json and lock files
     requires:
       count: 0
     if:
       has_author_in:
-        users: [ "svc-excavator-bot" ]
+        users:
+        - "svc-excavator-bot"
+        - "dependabot[bot]"
       only_changed_files:
         paths:
           - "^.*yarn.lock$"


### PR DESCRIPTION
Lots of security update PRs are a bit noisy.

Just wanna try this out on one repo to see if the [bot] syntax is right.