### PR TITLE
Ignore downloads folder in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@
 !README.md
 !bin/*
 !lib/**/*
-src/**/*
+!src/**/*
 **/__tests__/*
 **/__mocks__/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,7 @@
-*
+**/*
 !LICENSE
 !README.md
 !bin/*
 !lib/**/*
-!downloads/*
 **/__tests__/*
 **/__mocks__/*

--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@
 !README.md
 !bin/*
 !lib/**/*
+!downloads/*
 **/__tests__/*
 **/__mocks__/*

--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@
 !README.md
 !bin/*
 !lib/**/*
+src/**/*
 **/__tests__/*
 **/__mocks__/*

--- a/changelog/@unreleased/remove-downloads.v2.yml
+++ b/changelog/@unreleased/remove-downloads.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove downloads folder from published package
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/121


### PR DESCRIPTION
## Before this PR
conjure-client, gzipped, is 20MB because we include the downloads folder when publishing (which seems to only be used for testing, but correct me if I'm wrong)

## After this PR
==COMMIT_MSG==
Ignore downloads folder in .npmignore
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

