### PR TITLE
Generate compact endpoints

### DIFF
--- a/changelog/@unreleased/pr-137.v2.yml
+++ b/changelog/@unreleased/pr-137.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generate more compact service endpoint definitions to reduce code size
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/137

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "commander": "^2.19.0",
     "conjure-api": "^4.3.0",
-    "conjure-client": "^2.4.0",
+    "conjure-client": "^2.4.1",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "commander": "^2.19.0",
     "conjure-api": "^4.3.0",
-    "conjure-client": "^2.0.0",
+    "conjure-client": "^2.4.0",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/mediaTypeVisitorTest.ts
@@ -16,6 +16,7 @@
  */
 
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
+import { MediaType } from "conjure-client";
 import { MediaTypeVisitor } from "../mediaTypeVisitor";
 import { createHashableTypeName } from "../utils";
 
@@ -57,17 +58,17 @@ describe("testMediaTypeGenerator", () => {
     );
 
     it("returns correct media type for primitives", () => {
-        expect(visitor.primitive(PrimitiveType.STRING)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("MediaType.APPLICATION_OCTET_STREAM");
-        expect(visitor.primitive(PrimitiveType.ANY)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.RID)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.primitive(PrimitiveType.UUID)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.primitive(PrimitiveType.STRING)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual(MediaType.APPLICATION_OCTET_STREAM);
+        expect(visitor.primitive(PrimitiveType.ANY)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.RID)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.primitive(PrimitiveType.UUID)).toEqual(MediaType.APPLICATION_JSON);
     });
 
     it("produces error for unknown reference", () => {
@@ -76,39 +77,39 @@ describe("testMediaTypeGenerator", () => {
     });
 
     it("returns application/json for reference type", () => {
-        expect(visitor.reference(objectName)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.reference(objectName)).toEqual(MediaType.APPLICATION_JSON);
     });
 
     it("follows alias reference for media type", () => {
-        expect(visitor.reference(aliasName)).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.reference(binaryAliasName)).toEqual("MediaType.APPLICATION_OCTET_STREAM");
+        expect(visitor.reference(aliasName)).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.reference(binaryAliasName)).toEqual(MediaType.APPLICATION_OCTET_STREAM);
     });
 
     it("returns application/json for enum", () => {
-        expect(visitor.reference(enumName)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.reference(enumName)).toEqual(MediaType.APPLICATION_JSON);
     });
 
     it("follows optional element type for media type", () => {
-        expect(visitor.optional({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_OCTET_STREAM");
+        expect(visitor.optional({ itemType: objectReference })).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.optional({ itemType: binaryAliasReference })).toEqual(MediaType.APPLICATION_OCTET_STREAM);
     });
 
     it("returns application/json for list type", () => {
-        expect(visitor.list({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.list({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.list({ itemType: objectReference })).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.list({ itemType: binaryAliasReference })).toEqual(MediaType.APPLICATION_JSON);
     });
 
     it("returns application/json for set type", () => {
-        expect(visitor.set({ itemType: objectReference })).toEqual("MediaType.APPLICATION_JSON");
-        expect(visitor.set({ itemType: binaryAliasReference })).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.set({ itemType: objectReference })).toEqual(MediaType.APPLICATION_JSON);
+        expect(visitor.set({ itemType: binaryAliasReference })).toEqual(MediaType.APPLICATION_JSON);
     });
 
     it("returns application/json for map type", () => {
         expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
-            "MediaType.APPLICATION_JSON",
+            MediaType.APPLICATION_JSON,
         );
         expect(visitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
-            "MediaType.APPLICATION_JSON",
+            MediaType.APPLICATION_JSON,
         );
     });
 
@@ -118,6 +119,6 @@ describe("testMediaTypeGenerator", () => {
             externalReference: unusedTypeName,
             fallback: IType.primitive(PrimitiveType.ANY),
         };
-        expect(visitor.external(externalType)).toEqual("MediaType.APPLICATION_JSON");
+        expect(visitor.external(externalType)).toEqual(MediaType.APPLICATION_JSON);
     });
 });

--- a/src/commands/generate/__tests__/resources/services/optionalService.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalService.ts
@@ -1,4 +1,4 @@
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/services/optionalService.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalService.ts
@@ -1,5 +1,10 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
 export interface IOptionalService {
     foo(header: string, name?: string | null): Promise<void>;
 }
@@ -9,22 +14,21 @@ export class OptionalService {
     }
 
     public foo(header: string, name?: string | null): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "foo",
-            endpointPath: "/foo",
-            headers: {
+        return this.bridge.call<void>(
+            "OptionalService",
+            "foo",
+            "GET",
+            "/foo",
+            __undefined,
+            {
                 "Header": header,
             },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
+            {
                 "Query": name,
             },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -1,4 +1,4 @@
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -22,7 +22,7 @@ export class OutOfOrderPathService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 param2,
 
                 param1,

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -1,5 +1,10 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
 export interface IOutOfOrderPathService {
     foo(param1: string, param2: string): Promise<void>;
 }
@@ -9,23 +14,21 @@ export class OutOfOrderPathService {
     }
 
     public foo(param1: string, param2: string): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "foo",
-            endpointPath: "/{param2}/{param1}",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<void>(
+            "OutOfOrderPathService",
+            "foo",
+            "GET",
+            "/{param2}/{param1}",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 param2,
 
                 param1,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -1,4 +1,4 @@
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -1,5 +1,10 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
 export interface IParamTypeService {
     foo(body: string, header: string, path: string, query: string): Promise<void>;
 }
@@ -9,23 +14,23 @@ export class ParamTypeService {
     }
 
     public foo(body: string, header: string, path: string, query: string): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: body,
-            endpointName: "foo",
-            endpointPath: "/foo/{path}",
-            headers: {
+        return this.bridge.call<void>(
+            "ParamTypeService",
+            "foo",
+            "GET",
+            "/foo/{path}",
+            body,
+            {
                 "Header": header,
             },
-            method: "GET",
+            {
+                "Query": query,
+            },
             pathArguments: [
                 path,
             ],
-            queryArguments: {
-                "Query": query,
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -26,7 +26,7 @@ export class ParamTypeService {
             {
                 "Query": query,
             },
-            pathArguments: [
+            [
                 path,
             ],
             __undefined,

--- a/src/commands/generate/__tests__/resources/services/primitiveService.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveService.ts
@@ -1,4 +1,4 @@
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/services/primitiveService.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveService.ts
@@ -1,5 +1,10 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
 export interface IPrimitiveService {
     getPrimitive(): Promise<number>;
 }
@@ -9,20 +14,17 @@ export class PrimitiveService {
     }
 
     public getPrimitive(): Promise<number> {
-        return this.bridge.callEndpoint<number>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getPrimitive",
-            endpointPath: "/getPrimitive",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<number>(
+            "PrimitiveService",
+            "getPrimitive",
+            "GET",
+            "/getPrimitive",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
@@ -1,4 +1,4 @@
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
@@ -1,5 +1,10 @@
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
 export interface IServiceWithSafelongHeader {
     foo(investigation: number): Promise<void>;
 }
@@ -9,21 +14,19 @@ export class ServiceWithSafelongHeader {
     }
 
     public foo(investigation: number): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "foo",
-            endpointPath: "/foo",
-            headers: {
+        return this.bridge.call<void>(
+            "ServiceWithSafelongHeader",
+            "foo",
+            "GET",
+            "/foo",
+            __undefined,
+            {
                 "X-Investigation": investigation.toString(),
             },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -88,7 +88,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -105,7 +105,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -122,7 +122,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -139,7 +139,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -156,7 +156,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -203,7 +203,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -220,7 +220,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,
@@ -237,7 +237,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
 
                 branch,
@@ -256,7 +256,7 @@ export class TestService {
             __undefined,
             __undefined,
             __undefined,
-            pathArguments: [
+            [
                 datasetRid,
             ],
             __undefined,

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -1,7 +1,7 @@
 import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
 import { IDataset } from "../product-datasets/dataset";
 import { ICreateDatasetRequest } from "../product/createDatasetRequest";
-import { IHttpApiBridge, MediaType } from "conjure-client";
+import { IHttpApiBridge } from "conjure-client";
 
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -4,6 +4,11 @@ import { ICreateDatasetRequest } from "../product/createDatasetRequest";
 import { IHttpApiBridge, MediaType } from "conjure-client";
 
 /**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined = undefined;
+
+/**
  * A Markdown description of the service.
  * 
  */
@@ -43,263 +48,231 @@ export class TestService {
     }
 
     public getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }> {
-        return this.bridge.callEndpoint<{ [key: string]: IBackingFileSystem }>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getFileSystems",
-            endpointPath: "/catalog/fileSystems",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<{ [key: string]: IBackingFileSystem }>(
+            "TestService",
+            "getFileSystems",
+            "GET",
+            "/catalog/fileSystems",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
-        return this.bridge.callEndpoint<IDataset>({
-            binaryAsStream: true,
-            data: request,
-            endpointName: "createDataset",
-            endpointPath: "/catalog/datasets",
-            headers: {
+        return this.bridge.call<IDataset>(
+            "TestService",
+            "createDataset",
+            "POST",
+            "/catalog/datasets",
+            request,
+            {
                 "Test-Header": testHeaderArg,
             },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public getDataset(datasetRid: string): Promise<IDataset | null> {
-        return this.bridge.callEndpoint<IDataset | null>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getDataset",
-            endpointPath: "/catalog/datasets/{datasetRid}",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<IDataset | null>(
+            "TestService",
+            "getDataset",
+            "GET",
+            "/catalog/datasets/{datasetRid}",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
-        return this.bridge.callEndpoint<ReadableStream<Uint8Array>>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getRawData",
-            endpointPath: "/catalog/datasets/{datasetRid}/raw",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<ReadableStream<Uint8Array>>(
+            "TestService",
+            "getRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
-        });
+            __undefined,
+            "application/octet-stream"
+        );
     }
 
     public getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
-        return this.bridge.callEndpoint<ReadableStream<Uint8Array>>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getAliasedRawData",
-            endpointPath: "/catalog/datasets/{datasetRid}/raw-aliased",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<ReadableStream<Uint8Array>>(
+            "TestService",
+            "getAliasedRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
-        });
+            __undefined,
+            "application/octet-stream"
+        );
     }
 
     public maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
-        return this.bridge.callEndpoint<ReadableStream<Uint8Array> | null>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "maybeGetRawData",
-            endpointPath: "/catalog/datasets/{datasetRid}/raw-maybe",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<ReadableStream<Uint8Array> | null>(
+            "TestService",
+            "maybeGetRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-maybe",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_OCTET_STREAM,
-        });
+            __undefined,
+            "application/octet-stream"
+        );
     }
 
     public getAliasedString(datasetRid: string): Promise<string> {
-        return this.bridge.callEndpoint<string>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getAliasedString",
-            endpointPath: "/catalog/datasets/{datasetRid}/string-aliased",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<string>(
+            "TestService",
+            "getAliasedString",
+            "GET",
+            "/catalog/datasets/{datasetRid}/string-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: input,
-            endpointName: "uploadRawData",
-            endpointPath: "/catalog/datasets/upload-raw",
-            headers: {
-            },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_OCTET_STREAM,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<void>(
+            "TestService",
+            "uploadRawData",
+            "POST",
+            "/catalog/datasets/upload-raw",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+            __undefined
+        );
     }
 
     public uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: input,
-            endpointName: "uploadAliasedRawData",
-            endpointPath: "/catalog/datasets/upload-raw-aliased",
-            headers: {
-            },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_OCTET_STREAM,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<void>(
+            "TestService",
+            "uploadAliasedRawData",
+            "POST",
+            "/catalog/datasets/upload-raw-aliased",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+            __undefined
+        );
     }
 
     public getBranches(datasetRid: string): Promise<Array<string>> {
-        return this.bridge.callEndpoint<Array<string>>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getBranches",
-            endpointPath: "/catalog/datasets/{datasetRid}/branches",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<Array<string>>(
+            "TestService",
+            "getBranches",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public getBranchesDeprecated(datasetRid: string): Promise<Array<string>> {
-        return this.bridge.callEndpoint<Array<string>>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "getBranchesDeprecated",
-            endpointPath: "/catalog/datasets/{datasetRid}/branchesDeprecated",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<Array<string>>(
+            "TestService",
+            "getBranchesDeprecated",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branchesDeprecated",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public resolveBranch(datasetRid: string, branch: string): Promise<string | null> {
-        return this.bridge.callEndpoint<string | null>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "resolveBranch",
-            endpointPath: "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<string | null>(
+            "TestService",
+            "resolveBranch",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
 
                 branch,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public testParam(datasetRid: string): Promise<string | null> {
-        return this.bridge.callEndpoint<string | null>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "testParam",
-            endpointPath: "/catalog/datasets/{datasetRid}/testParam",
-            headers: {
-            },
-            method: "GET",
+        return this.bridge.call<string | null>(
+            "TestService",
+            "testParam",
+            "GET",
+            "/catalog/datasets/{datasetRid}/testParam",
+            __undefined,
+            __undefined,
+            __undefined,
             pathArguments: [
                 datasetRid,
             ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined
+        );
     }
 
     public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
-        return this.bridge.callEndpoint<number>({
-            binaryAsStream: true,
-            data: query,
-            endpointName: "testQueryParams",
-            endpointPath: "/catalog/test-query-params",
-            headers: {
-            },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
+        return this.bridge.call<number>(
+            "TestService",
+            "testQueryParams",
+            "POST",
+            "/catalog/test-query-params",
+            query,
+            __undefined,
+            {
                 "different": something,
 
                 "implicit": implicit,
@@ -310,23 +283,21 @@ export class TestService {
 
                 "optionalEnd": optionalEnd,
             },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: query,
-            endpointName: "testNoResponseQueryParams",
-            endpointPath: "/catalog/test-no-response-query-params",
-            headers: {
-            },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
+        return this.bridge.call<void>(
+            "TestService",
+            "testNoResponseQueryParams",
+            "POST",
+            "/catalog/test-no-response-query-params",
+            query,
+            __undefined,
+            {
                 "different": something,
 
                 "implicit": implicit,
@@ -337,101 +308,88 @@ export class TestService {
 
                 "optionalEnd": optionalEnd,
             },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testBoolean(): Promise<boolean> {
-        return this.bridge.callEndpoint<boolean>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "testBoolean",
-            endpointPath: "/catalog/boolean",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<boolean>(
+            "TestService",
+            "testBoolean",
+            "GET",
+            "/catalog/boolean",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testDouble(): Promise<number | "NaN"> {
-        return this.bridge.callEndpoint<number | "NaN">({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "testDouble",
-            endpointPath: "/catalog/double",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<number | "NaN">(
+            "TestService",
+            "testDouble",
+            "GET",
+            "/catalog/double",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testInteger(): Promise<number> {
-        return this.bridge.callEndpoint<number>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "testInteger",
-            endpointPath: "/catalog/integer",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<number>(
+            "TestService",
+            "testInteger",
+            "GET",
+            "/catalog/integer",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testPostOptional(maybeString?: string | null): Promise<string | null> {
-        return this.bridge.callEndpoint<string | null>({
-            binaryAsStream: true,
-            data: maybeString,
-            endpointName: "testPostOptional",
-            endpointPath: "/catalog/optional",
-            headers: {
-            },
-            method: "POST",
-            pathArguments: [
-            ],
-            queryArguments: {
-            },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+        return this.bridge.call<string | null>(
+            "TestService",
+            "testPostOptional",
+            "POST",
+            "/catalog/optional",
+            maybeString,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 
     public testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
-        return this.bridge.callEndpoint<void>({
-            binaryAsStream: true,
-            data: undefined,
-            endpointName: "testOptionalIntegerAndDouble",
-            endpointPath: "/catalog/optional-integer-double",
-            headers: {
-            },
-            method: "GET",
-            pathArguments: [
-            ],
-            queryArguments: {
+        return this.bridge.call<void>(
+            "TestService",
+            "testOptionalIntegerAndDouble",
+            "GET",
+            "/catalog/optional-integer-double",
+            __undefined,
+            __undefined,
+            {
                 "maybeInteger": maybeInteger,
 
                 "maybeDouble": maybeDouble,
             },
-            requestMediaType: MediaType.APPLICATION_JSON,
-            responseMediaType: MediaType.APPLICATION_JSON,
-        });
+            __undefined,
+            __undefined,
+            __undefined
+        );
     }
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -109,7 +109,7 @@ describe("serviceGenerator", () => {
         const contents = fs.readFileSync(outFile, "utf8");
         expect(contents).toContain("returnsVoid(): Promise<void>;");
         expect(contents).toContain("returnsVoid(): Promise<void> {");
-        expect(contents).toContain("return this.bridge.callEndpoint<void>({");
+        expect(contents).toContain("return this.bridge.call<void>(");
     });
 
     it("handles binary body and return types", async () => {
@@ -133,8 +133,7 @@ describe("serviceGenerator", () => {
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
         expect(contents).toContain("foo(): Promise<ReadableStream<Uint8Array>>;");
-        expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_JSON`);
-        expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
+        expect(contents).toContain(`"application\/octet-stream"\n`);
     });
 
     it("handle binary return and json request types", async () => {
@@ -167,8 +166,8 @@ describe("serviceGenerator", () => {
         expect(contents).toContain(
             "foo(body: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<ReadableStream<Uint8Array>>;",
         );
-        expect(contents).toContain(`requestMediaType: MediaType.APPLICATION_OCTET_STREAM`);
-        expect(contents).toContain(`responseMediaType: MediaType.APPLICATION_OCTET_STREAM`);
+        expect(contents).toContain(`"application\/octet-stream",\n`);
+        expect(contents).toContain(`"application\/octet-stream"\n`);
     });
 
     it("emits imports and correct signature for service with references", async () => {
@@ -334,7 +333,7 @@ describe("serviceGenerator", () => {
         const contents = fs.readFileSync(outFile, "utf8");
         expect(contents).toContain("foo(header: string): Promise<void>;");
         expect(contents).toContain("foo(header: string): Promise<void> {");
-        expect(contents).toMatch(/headers: {\s*"Header": header,\s*}/);
+        expect(contents).toMatch(/{\s*"Header": header,\s*}/);
     });
 
     it("throws on multiple body args", async () => {

--- a/src/commands/generate/mediaTypeVisitor.ts
+++ b/src/commands/generate/mediaTypeVisitor.ts
@@ -26,24 +26,25 @@ import {
     ITypeVisitor,
     PrimitiveType,
 } from "conjure-api";
+import { MediaType } from "conjure-client";
 import { createHashableTypeName } from "./utils";
 
-export class MediaTypeVisitor implements ITypeVisitor<string> {
+export class MediaTypeVisitor implements ITypeVisitor<MediaType> {
     constructor(private knownTypes: Map<string, ITypeDefinition>) {}
 
-    public external = (_: IExternalReference): string => {
-        return "MediaType.APPLICATION_JSON";
+    public external = (_: IExternalReference): MediaType => {
+        return MediaType.APPLICATION_JSON;
     };
-    public list = (_: IListType): string => {
-        return "MediaType.APPLICATION_JSON";
+    public list = (_: IListType): MediaType => {
+        return MediaType.APPLICATION_JSON;
     };
-    public map = (_: IMapType): string => {
-        return "MediaType.APPLICATION_JSON";
+    public map = (_: IMapType): MediaType => {
+        return MediaType.APPLICATION_JSON;
     };
-    public optional = (obj: IOptionalType): string => {
+    public optional = (obj: IOptionalType): MediaType => {
         return IType.visit(obj.itemType, this);
     };
-    public primitive = (obj: PrimitiveType): string => {
+    public primitive = (obj: PrimitiveType): MediaType => {
         switch (obj) {
             case PrimitiveType.STRING:
             case PrimitiveType.DATETIME:
@@ -55,26 +56,26 @@ export class MediaTypeVisitor implements ITypeVisitor<string> {
             case PrimitiveType.ANY:
             case PrimitiveType.BOOLEAN:
             case PrimitiveType.UUID:
-                return "MediaType.APPLICATION_JSON";
+                return MediaType.APPLICATION_JSON;
             case PrimitiveType.BINARY:
-                return "MediaType.APPLICATION_OCTET_STREAM";
+                return MediaType.APPLICATION_OCTET_STREAM;
             default:
                 throw new Error("unknown primitive type");
         }
     };
-    public reference = (obj: ITypeName): string => {
+    public reference = (obj: ITypeName): MediaType => {
         const typeDefinition = this.knownTypes.get(createHashableTypeName(obj));
         if (typeDefinition == null) {
             throw new Error(`unknown reference type. package: '${obj.package}', name: '${obj.name}'`);
         } else if (ITypeDefinition.isAlias(typeDefinition)) {
             return IType.visit(typeDefinition.alias.alias, this);
         }
-        return "MediaType.APPLICATION_JSON";
+        return MediaType.APPLICATION_JSON;
     };
-    public set = (_: ISetType): string => {
-        return "MediaType.APPLICATION_JSON";
+    public set = (_: ISetType): MediaType => {
+        return MediaType.APPLICATION_JSON;
     };
-    public unknown = (_: IType): string => {
-        return "MediaType.APPLICATION_JSON";
+    public unknown = (_: IType): MediaType => {
+        return MediaType.APPLICATION_JSON;
     };
 }

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -72,7 +72,7 @@ export function generateService(
 
     const endpointSignatures: MethodDeclarationStructure[] = [];
     const endpointImplementations: MethodDeclarationStructure[] = [];
-    const imports: ImportDeclarationStructure[] = [HTTP_API_BRIDGE_IMPORT, MEDIA_TYPE_IMPORT];
+    const imports: ImportDeclarationStructure[] = [HTTP_API_BRIDGE_IMPORT];
     sourceFile.addVariableStatement({
         declarationKind: VariableDeclarationKind.Const,
         docs: ["Constant reference to `undefined` that we expect to get minified and therefore reduce total code size"],

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -240,7 +240,7 @@ function generateEndpointBody(
         if (pathParamsFromPath.length === 0) {
             writer.writeLine(`${UNDEFINED_CONSTANT},`);
         } else {
-            writer.write("pathArguments: [");
+            writer.write("[");
             pathParamsFromPath.forEach(pathArgName => writer.indent().writeLine(pathArgName + ","));
             writer.writeLine("],");
         }

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -45,16 +45,11 @@ import { CONJURE_CLIENT } from "./utils";
 
 /** Type used in the generation of the service class. Expected to be provided by conjure-client */
 const HTTP_API_BRIDGE_TYPE = "IHttpApiBridge";
-const MEDIA_TYPE = "MediaType";
 /** Variable name used in the generation of the service class. */
 const BRIDGE = "bridge";
 const HTTP_API_BRIDGE_IMPORT = {
     moduleSpecifier: CONJURE_CLIENT,
     namedImports: [{ name: HTTP_API_BRIDGE_TYPE }],
-};
-const MEDIA_TYPE_IMPORT = {
-    moduleSpecifier: CONJURE_CLIENT,
-    namedImports: [{ name: MEDIA_TYPE }],
 };
 
 const UNDEFINED_CONSTANT = "__undefined";

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -214,7 +214,7 @@ function generateEndpointBody(
 
     return writer => {
         writer
-            .write(`return this.${BRIDGE}.callEndpoint<${returnTsType}>(`)
+            .write(`return this.${BRIDGE}.call<${returnTsType}>(`)
             .writeLine(`"${serviceName}",`)
             .writeLine(`"${endpointDefinition.endpointName}",`)
             .writeLine(`"${endpointDefinition.httpMethod}",`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,10 +1526,10 @@ conjure-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.3.0.tgz#c778736f369e7c749a86118e14dab83deb698ace"
   integrity sha512-AnZe6qkiCRSsfuQMgA556dFs+/DbXpCK2uuhq9bHn36dSbKi+6HUDntpc9jkVPzWOecLXGqy+JAD6IKV8c9Sqw==
 
-conjure-client@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-2.0.0.tgz#4c03b4de0b91a9907a141087265b545c3e4ec801"
-  integrity sha512-cFC3GUx0ErzkWu/FndfF43s/S46qoPwW+v5u/Qo4wzX7pZ2H0aWCC1UGa7Xb+ArEfydHkFpyFyBFQOSN3dYiSQ==
+conjure-client@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-2.4.0.tgz#422f23ba7ebe7110fae6cb2b3004df22a5ab22e8"
+  integrity sha512-cjyprSa13UEJmn/ja13RNatfAlhMW1RLVt9wa9zp9ioud+0y5+rUq5RQ9dqQ8NN005CouKuJWWTwghhVFVnXFQ==
   dependencies:
     web-streams-polyfill "^2.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,10 +1526,10 @@ conjure-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.3.0.tgz#c778736f369e7c749a86118e14dab83deb698ace"
   integrity sha512-AnZe6qkiCRSsfuQMgA556dFs+/DbXpCK2uuhq9bHn36dSbKi+6HUDntpc9jkVPzWOecLXGqy+JAD6IKV8c9Sqw==
 
-conjure-client@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-2.4.0.tgz#422f23ba7ebe7110fae6cb2b3004df22a5ab22e8"
-  integrity sha512-cjyprSa13UEJmn/ja13RNatfAlhMW1RLVt9wa9zp9ioud+0y5+rUq5RQ9dqQ8NN005CouKuJWWTwghhVFVnXFQ==
+conjure-client@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-2.4.1.tgz#f230d13d9cc6b8699d3f26955b806d431b652fe9"
+  integrity sha512-D+m/j8G54CQVE/2i0RmgCZQXNqNy7TGOl4KrqVZV4LsTYhjrWXmBHvfHM+mhyPs69QWfDEgW48Yy/zUwEbuMYA==
   dependencies:
     web-streams-polyfill "^2.0.6"
 


### PR DESCRIPTION
Pending https://github.com/palantir/conjure-typescript-runtime/pull/105

## Before this PR
We would generate endpoints that used `conjure-client`s `HttpBridge.callEndpoint` method. While nice and human readable this had the unfortunate consequence of leading to a bloat in code size since all of the field names were generated and preserved even through minification.

## After this PR
==COMMIT_MSG==
Generate more compact service endpoint definitions to reduce code size
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

