### PR TITLE
Add type to undefined constant

### DIFF
--- a/changelog/@unreleased/pr-140.v2.yml
+++ b/changelog/@unreleased/pr-140.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Include type annotation on undefined constant.
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/140

--- a/src/commands/generate/__tests__/resources/services/optionalService.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalService.ts
@@ -3,7 +3,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 export interface IOptionalService {
     foo(header: string, name?: string | null): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -3,7 +3,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 export interface IOutOfOrderPathService {
     foo(param1: string, param2: string): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -3,7 +3,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 export interface IParamTypeService {
     foo(body: string, header: string, path: string, query: string): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/primitiveService.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveService.ts
@@ -3,7 +3,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 export interface IPrimitiveService {
     getPrimitive(): Promise<number>;

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
@@ -3,7 +3,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 export interface IServiceWithSafelongHeader {
     foo(investigation: number): Promise<void>;

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -6,7 +6,7 @@ import { IHttpApiBridge } from "conjure-client";
 /**
  * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
  */
-const __undefined = undefined;
+const __undefined: any = undefined;
 
 /**
  * A Markdown description of the service.

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -71,7 +71,7 @@ export function generateService(
     sourceFile.addVariableStatement({
         declarationKind: VariableDeclarationKind.Const,
         docs: ["Constant reference to `undefined` that we expect to get minified and therefore reduce total code size"],
-        declarations: [{ name: UNDEFINED_CONSTANT, initializer: "undefined" }],
+        declarations: [{ name: UNDEFINED_CONSTANT, type: "any", initializer: "undefined" }],
     });
     definition.endpoints.forEach(endpointDefinition => {
         const parameters: ParameterDeclarationStructure[] = endpointDefinition.args


### PR DESCRIPTION
## Before this PR
Compiling conjure-typescript generated files fails with the following error due to changes in #137.
```
error TS7005: Variable '__undefined' implicitly has an 'any' type.
```

## After this PR
Compiling conjure-typescript generated files succeeds.

Ideally we would have tests that compile the generated code. But I'm not the right person to make that change, so I'll leave it for a follow up.

