### PR TITLE
Add incubating doc to tagged endpoints

### DIFF
--- a/changelog/@unreleased/pr-150.v2.yml
+++ b/changelog/@unreleased/pr-150.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Endpoints are documented as incubating if included in tags
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/150

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "commander": "^2.19.0",
-    "conjure-api": "^4.13.0",
+    "conjure-api": "^4.14.1",
     "conjure-client": "^2.4.1",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.11",

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -51,6 +51,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/getPrimitive",
                         markers: [],
                         returns: { primitive: PrimitiveType.INTEGER, type: "primitive" },
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "PrimitiveService", package: "com.palantir.services" },
@@ -72,12 +73,14 @@ describe("serviceGenerator", () => {
                                 markers: [],
                                 paramType: IParameterType.header({ paramId: "X-Investigation" }),
                                 type: IType.primitive(PrimitiveType.SAFELONG),
+                                tags: [],
                             },
                         ],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "ServiceWithSafelongHeader", package: "com.palantir.services" },
@@ -98,6 +101,7 @@ describe("serviceGenerator", () => {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/bar",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -123,6 +127,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/bar",
                         markers: [],
                         returns: { primitive: PrimitiveType.BINARY, type: "primitive" },
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -147,6 +152,7 @@ describe("serviceGenerator", () => {
                                 markers: [],
                                 paramType: IParameterType.body({}),
                                 type: { primitive: PrimitiveType.BINARY, type: "primitive" },
+                                tags: [],
                             },
                         ],
                         endpointName: "foo",
@@ -154,6 +160,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/bar",
                         markers: [],
                         returns: { primitive: PrimitiveType.BINARY, type: "primitive" },
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -181,6 +188,7 @@ describe("serviceGenerator", () => {
                                 markers: [],
                                 paramType: IParameterType.body({}),
                                 type: localObject.reference,
+                                tags: [],
                             },
                         ],
                         endpointName: "foo",
@@ -188,6 +196,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/foo",
                         markers: [],
                         returns: foreignObject.reference,
+                        tags: [],
                     },
                 ],
                 serviceName: {
@@ -219,6 +228,7 @@ describe("serviceGenerator", () => {
                                 markers: [],
                                 paramType: IParameterType.body({}),
                                 type: stringType,
+                                tags: [],
                             },
                             {
                                 argName: "header",
@@ -228,6 +238,7 @@ describe("serviceGenerator", () => {
                                     type: "header",
                                 },
                                 type: stringType,
+                                tags: [],
                             },
                             {
                                 argName: "path",
@@ -237,6 +248,7 @@ describe("serviceGenerator", () => {
                                     type: "path",
                                 },
                                 type: stringType,
+                                tags: [],
                             },
                             {
                                 argName: "query",
@@ -246,12 +258,14 @@ describe("serviceGenerator", () => {
                                     type: "query",
                                 },
                                 type: stringType,
+                                tags: [],
                             },
                         ],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo/{path}",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "ParamTypeService", package: "com.palantir.services" },
@@ -276,6 +290,7 @@ describe("serviceGenerator", () => {
                                     type: "path",
                                 },
                                 type: stringType,
+                                tags: [],
                             },
                             {
                                 argName: "param2",
@@ -285,12 +300,14 @@ describe("serviceGenerator", () => {
                                     type: "path",
                                 },
                                 type: stringType,
+                                tags: [],
                             },
                         ],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/{param2}/{param1}",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "OutOfOrderPathService", package: "com.palantir.services" },
@@ -312,6 +329,7 @@ describe("serviceGenerator", () => {
                                 markers: [],
                                 paramType: IParameterType.header({ paramId: "Header" }),
                                 type: stringType,
+                                tags: [],
                             },
                         ],
                         auth: {
@@ -322,6 +340,7 @@ describe("serviceGenerator", () => {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -349,6 +368,7 @@ describe("serviceGenerator", () => {
                                     markers: [],
                                     paramType: IParameterType.body({}),
                                     type: stringType,
+                                    tags: [],
                                 },
                                 {
                                     argName: "body2",
@@ -358,12 +378,14 @@ describe("serviceGenerator", () => {
                                         type: "body",
                                     },
                                     type: stringType,
+                                    tags: [],
                                 },
                             ],
                             endpointName: "foo",
                             httpMethod: HttpMethod.GET,
                             httpPath: "/foo",
                             markers: [],
+                            tags: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -389,12 +411,14 @@ describe("serviceGenerator", () => {
                                     markers: [],
                                     paramType: IParameterType.header({} as any),
                                     type: stringType,
+                                    tags: [],
                                 },
                             ],
                             endpointName: "foo",
                             httpMethod: HttpMethod.GET,
                             httpPath: "/foo",
                             markers: [],
+                            tags: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -420,12 +444,14 @@ describe("serviceGenerator", () => {
                                     markers: [],
                                     paramType: IParameterType.query({} as any),
                                     type: stringType,
+                                    tags: [],
                                 },
                             ],
                             endpointName: "foo",
                             httpMethod: HttpMethod.GET,
                             httpPath: "/foo",
                             markers: [],
+                            tags: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -450,6 +476,7 @@ describe("serviceGenerator", () => {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -481,6 +508,72 @@ export interface IMyService {
         );
     });
 
+    it("emits endpoint with incubating doc", async () => {
+        await generateService(
+            {
+                endpoints: [
+                    {
+                        args: [],
+                        tags: ['incubating'],
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/foo",
+                        markers: [],
+                    },
+                ],
+                serviceName: { name: "MyService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+        );
+        const outFile = path.join(outDir, "services/myService.ts");
+        const contents = fs.readFileSync(outFile, "utf8");
+        expect(contents).toContain(
+            `
+export interface IMyService {
+    /**
+     * @incubating
+     */
+    foo(): Promise<void>;
+}
+`);
+
+    });
+
+    it("emits endpoint with incubating and deprecated docs", async () => {
+        await generateService(
+            {
+                endpoints: [
+                    {
+                        args: [],
+                        deprecated: "to be replaced",
+                        tags: ['incubating'],
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/foo",
+                        markers: [],
+                    },
+                ],
+                serviceName: { name: "MyService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+        );
+        const outFile = path.join(outDir, "services/myService.ts");
+        const contents = fs.readFileSync(outFile, "utf8");
+        expect(contents).toContain(
+            `
+export interface IMyService {
+    /**
+     * @deprecated to be replaced
+     * @incubating
+     */
+    foo(): Promise<void>;
+}
+`);
+
+    });
+
     it("emits service with optional params", async () => {
         await generateService(
             {
@@ -492,12 +585,14 @@ export interface IMyService {
                                 markers: [],
                                 paramType: IParameterType.query({ paramId: "Query" }),
                                 type: IType.optional({ itemType: IType.primitive(PrimitiveType.STRING) }),
+                                tags: [],
                             },
                             {
                                 argName: "header",
                                 markers: [],
                                 paramType: IParameterType.header({ paramId: "Header" }),
                                 type: stringType,
+                                tags: [],
                             },
                         ],
                         auth: {
@@ -508,6 +603,7 @@ export interface IMyService {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        tags: [],
                     },
                 ],
                 serviceName: { name: "OptionalService", package: "com.palantir.services" },

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -514,7 +514,7 @@ export interface IMyService {
                 endpoints: [
                     {
                         args: [],
-                        tags: ['incubating'],
+                        tags: ["incubating"],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
@@ -536,8 +536,8 @@ export interface IMyService {
      */
     foo(): Promise<void>;
 }
-`);
-
+`,
+        );
     });
 
     it("emits endpoint with incubating and deprecated docs", async () => {
@@ -547,7 +547,7 @@ export interface IMyService {
                     {
                         args: [],
                         deprecated: "to be replaced",
-                        tags: ['incubating'],
+                        tags: ["incubating"],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
@@ -570,8 +570,8 @@ export interface IMyService {
      */
     foo(): Promise<void>;
 }
-`);
-
+`,
+        );
     });
 
     it("emits service with optional params", async () => {

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -59,6 +59,7 @@ describe("simpleAst", () => {
                             primitive: PrimitiveType.INTEGER,
                             type: "primitive",
                         },
+                        tags: [],
                     },
                 ],
                 serviceName: {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -41,7 +41,7 @@ import { SimpleAst } from "./simpleAst";
 import { StringConversionTypeVisitor } from "./stringConversionTypeVisitor";
 import { TsArgumentTypeVisitor } from "./tsArgumentTypeVisitor";
 import { TsReturnTypeVisitor } from "./tsReturnTypeVisitor";
-import { addDeprecatedToDocs, CONJURE_CLIENT } from "./utils";
+import { addDeprecatedToDocs, addIncubatingDocs, CONJURE_CLIENT } from "./utils";
 
 /** Type used in the generation of the service class. Expected to be provided by conjure-client */
 const HTTP_API_BRIDGE_TYPE = "IHttpApiBridge";
@@ -102,7 +102,7 @@ export function generateService(
             parameters,
             returnType: `Promise<${returnTsType}>`,
         };
-        const docs = addDeprecatedToDocs(endpointDefinition);
+        const docs = addIncubatingDocs(endpointDefinition, addDeprecatedToDocs(endpointDefinition));
         if (docs != null) {
             signature.docs = docs;
         }

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -106,13 +106,16 @@ export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefin
     return typeDefintion.docs != null ? [typeDefintion.docs] : undefined;
 }
 
-export function addIncubatingDocs(endpointDefinition: IEndpointDefinition, existingDocs: string[] | undefined): string[] | undefined {
+export function addIncubatingDocs(
+    endpointDefinition: IEndpointDefinition,
+    existingDocs: string[] | undefined,
+): string[] | undefined {
     if (endpointDefinition.tags !== undefined && endpointDefinition.tags.indexOf("incubating") >= 0) {
-        if (existingDocs == undefined) {
+        if (existingDocs === undefined) {
             return [`@incubating`];
         } else {
             return [existingDocs + `\n@incubating`];
         }
     }
-    return existingDocs
+    return existingDocs;
 }

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -105,3 +105,14 @@ export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefin
     }
     return typeDefintion.docs != null ? [typeDefintion.docs] : undefined;
 }
+
+export function addIncubatingDocs(endpointDefinition: IEndpointDefinition, existingDocs: string[] | undefined): string[] | undefined {
+    if (endpointDefinition.tags !== undefined && endpointDefinition.tags.indexOf("incubating") >= 0) {
+        if (existingDocs == undefined) {
+            return [`@incubating`];
+        } else {
+            return [existingDocs + `\n@incubating`];
+        }
+    }
+    return existingDocs
+}

--- a/versions.props
+++ b/versions.props
@@ -1,3 +1,3 @@
 # User versions.props so that excavator can automatically keep our version up to date
 com.palantir.conjure.verification:* = 0.18.5
-com.palantir.conjure:conjure = 4.13.0
+com.palantir.conjure:conjure = 4.14.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,10 +1516,10 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-conjure-api@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.13.0.tgz#3afb10e2ba3fefb582ce7cb20b259d096aab6895"
-  integrity sha512-ATtXX42n9WwEOrMdQpMYJreauyiBDf+5XmXATjE5Ky2nozlgu2DNXXajrXKzPhBM1XEjeTH4JS5zwlE4/JhnmA==
+conjure-api@^4.14.1:
+  version "4.14.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/conjure-api/-/conjure-api-4.14.1.tgz#d999ca713b41fac6e56e35ba377ece8662e016b6"
+  integrity sha1-2ZnKcTtB+sblbjW6N37OhmLgFrY=
 
 conjure-client@^2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1518,7 +1518,7 @@ concat-stream@^1.5.0:
 
 conjure-api@^4.14.1:
   version "4.14.1"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/conjure-api/-/conjure-api-4.14.1.tgz#d999ca713b41fac6e56e35ba377ece8662e016b6"
+  resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.14.1.tgz#d999ca713b41fac6e56e35ba377ece8662e016b6"
   integrity sha1-2ZnKcTtB+sblbjW6N37OhmLgFrY=
 
 conjure-client@^2.4.1:


### PR DESCRIPTION
## Before this PR
Typescript definitions did not include information about incubating APIs, which Java generated code now includes.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Endpoints are documented as incubating if included in tags
==COMMIT_MSG==

## Possible downsides?
There is no tooling in VSCode for example for using this information.
