### PR TITLE
Move conjure-client to be a direct dependency

### DIFF
--- a/changelog/@unreleased/pr-151.v2.yml
+++ b/changelog/@unreleased/pr-151.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Make conjure-client a direct dependency instead of a peer dependency
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/151

--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -47,10 +47,8 @@ describe("generate command", () => {
                 scripts: {
                     build: "tsc",
                 },
-                dependencies: {},
-                peerDependencies: { "conjure-client": "1.0.0" },
+                dependencies: { "conjure-client": "1.0.0" },
                 devDependencies: {
-                    "conjure-client": "1.0.0",
                     typescript: "2.7.2",
                 },
                 author: "Conjure",
@@ -88,10 +86,8 @@ describe("generate command", () => {
                 scripts: {
                     build: "tsc",
                 },
-                dependencies: {},
-                peerDependencies: { "conjure-client": "1.0.0" },
+                dependencies: { "conjure-client": "1.0.0" },
                 devDependencies: {
-                    "conjure-client": "1.0.0",
                     typescript: "2.7.2",
                 },
                 author: "Conjure",
@@ -130,10 +126,8 @@ describe("generate command", () => {
                 scripts: {
                     build: "tsc",
                 },
-                dependencies: {},
-                peerDependencies: { "conjure-client": "1.0.0" },
+                dependencies: { "conjure-client": "1.0.0" },
                 devDependencies: {
-                    "conjure-client": "1.0.0",
                     typescript: "2.7.2",
                 },
                 author: "Conjure",

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -174,7 +174,7 @@ export async function createPackageJson(
         sideEffects: false,
         scripts: { build: "tsc" },
         dependencies: {
-            "conjure-client": projectPackageJson.dependencies["conjure-client"]
+            "conjure-client": projectPackageJson.dependencies["conjure-client"],
         },
         devDependencies: { typescript: projectPackageJson.devDependencies.typescript },
         author: "Conjure",

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -166,7 +166,6 @@ export async function createPackageJson(
     packageVersion: string,
     productDependencies?: string,
 ): Promise<IPackageJson> {
-    const peerDependencies = { "conjure-client": projectPackageJson.dependencies["conjure-client"] };
     const packageJson: IPackageJson = {
         name: packageName!,
         version: packageVersion!,
@@ -174,9 +173,10 @@ export async function createPackageJson(
         types: "index.d.ts",
         sideEffects: false,
         scripts: { build: "tsc" },
-        dependencies: {},
-        peerDependencies,
-        devDependencies: { ...peerDependencies, typescript: projectPackageJson.devDependencies.typescript },
+        dependencies: {
+            "conjure-client": projectPackageJson.dependencies["conjure-client"]
+        },
+        devDependencies: { typescript: projectPackageJson.devDependencies.typescript },
         author: "Conjure",
         license: "UNLICENSED",
     };


### PR DESCRIPTION
## Before this PR
See reasoning discussed in https://github.com/palantir/conjure-typescript-runtime/pull/105#issuecomment-629893232

BLUF: conjure-client does not require 1 installation to work correctly with generated conjure service packages, so it does not need to be a peer dependency

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Move conjure-client to be a direct dependency
==COMMIT_MSG==


