### PR TITLE
Add JSDoc comments to class endpoint implementations

### DIFF
--- a/changelog/@unreleased/pr-152.v2.yml
+++ b/changelog/@unreleased/pr-152.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add JSDoc comments to class endpoint implementations
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/152

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -48,6 +48,10 @@ export class TestService {
     constructor(private bridge: IHttpApiBridge) {
     }
 
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     * 
+     */
     public getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }> {
         return this.bridge.call<{ [key: string]: IBackingFileSystem }>(
             "TestService",
@@ -212,6 +216,11 @@ export class TestService {
         );
     }
 
+    /**
+     * Gets all branches of this dataset.
+     * 
+     * @deprecated use getBranches instead
+     */
     public getBranchesDeprecated(datasetRid: string): Promise<Array<string>> {
         return this.bridge.call<Array<string>>(
             "TestService",

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -120,6 +120,7 @@ export function generateService(
             returnType: `Promise<${returnTsType}>`,
             // this appears to be a no-op by ts-simple-ast, since default in typescript is public
             scope: Scope.Public,
+            docs: docs
         });
     });
 

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -120,7 +120,7 @@ export function generateService(
             returnType: `Promise<${returnTsType}>`,
             // this appears to be a no-op by ts-simple-ast, since default in typescript is public
             scope: Scope.Public,
-            docs: docs
+            docs,
         });
     });
 


### PR DESCRIPTION
## Before this PR
JSDoc comments were only added interfaces rather than class implementations.  Many consumers only reference classes rather than interfaces in their code which limits the ability to lint for deprecated usages for example.

## After this PR
==COMMIT_MSG==
Add JSDoc comments to class endpoint implementations
==COMMIT_MSG==

## Possible downsides?
The comments are replicated twice in the implemented code.

