### PR TITLE
Fix publish failing due to dirty version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 node_modules/
 npm-debug.log
 yarn-error.log
+.npmrc
 
 # Gradle
 .gradle

--- a/changelog/@unreleased/pr-169.v2.yml
+++ b/changelog/@unreleased/pr-169.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix publish failing due to dirty version
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/169

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "npm-run-all clean compile verify",
-    "circle-publish": "./scripts/circle-publish-npm && ./gradlew publish",
+    "circle-publish": "./gradlew publish && ./scripts/circle-publish-npm",
     "clean": "rm -rf dist lib",
     "compile": "npm-run-all -p compile-ts compile-dist",
     "compile-dist": "webpack --config webpack.config.js && cp bin/conjure-typescript.bat dist/bin",


### PR DESCRIPTION
## Before this PR
Publishing is failing due to a dirty git version ([circle](https://app.circleci.com/pipelines/github/palantir/conjure-typescript/117/workflows/dde67270-1630-4871-99cd-94a260b9a5ca/jobs/525)). This is because:
* We add a .npmrc file during npm publish ([ref](https://github.com/palantir/conjure-typescript/blob/b126dd82dd85ffbf2e0a572b455b61079de06fb7/scripts/circle-publish-npm#L17))
* We update the package.json with the current version ([ref](https://github.com/palantir/conjure-typescript/blob/b126dd82dd85ffbf2e0a572b455b61079de06fb7/scripts/circle-publish-npm#L22))

## After this PR

* Hacky workaround is to run the gradle-based dist publishing first as at that time the git state is still clean. Not super sure how to fix the updated package.json producing a dirty git version otherwise.

==COMMIT_MSG==
Fix publish failing due to dirty version
==COMMIT_MSG==