### PR TITLE
Fix published dist file structure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,12 +35,14 @@ task verifyBinariesExist() {
 }
 
 task distTar(type: Tar) {
-    archiveFileName = "conjure-typescript-${gitVersion()}.tgz"
+    String publicationName = "conjure-typescript-${gitVersion()}"
+
+    archiveFileName = "${publicationName}.tgz"
     destinationDirectory = layout.buildDirectory.dir('dist')
 
     compression Compression.GZIP
 
-    into('/bin') {
+    into("/${publicationName}/bin") {
         from 'dist/bin'
     }
 

--- a/changelog/@unreleased/pr-175.v2.yml
+++ b/changelog/@unreleased/pr-175.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix published dist file structure
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/175


### PR DESCRIPTION
## Before this PR
Projects depending on conjure-typescript are breaking with:
```
java.lang.IllegalStateException: Couldn't find expected file after extracting archive /home/circleci/.gradle/caches/modules-2/files-2.1/com.palantir.conjure.typescript/conjure-typescript/4.8.0/<checksum>/conjure-typescript-4.8.0.tgz:
task ':extractConjureTypeScript'
property 'executable'
```

This is because we messed up the directory structure of the published dist in https://github.com/palantir/conjure-typescript/pull/168.

Expected is:
```
conjure-typescript-4.8.0.tgz
  |-conjure-typescript-4.8.0
    |-bin
      |-[...]
```

However we published:
```
conjure-typescript-4.8.0.tgz
  |-bin
    |-[...]
```


## After this PR
==COMMIT_MSG==
Fix published dist file structure
==COMMIT_MSG==