### PR TITLE
Bump conjure-client to latest version

### DIFF
--- a/changelog/@unreleased/pr-183.v2.yml
+++ b/changelog/@unreleased/pr-183.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump dependency for conjure-client to 2.5.0.
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/183

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,8 +1525,6 @@ conjure-client@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/conjure-client/-/conjure-client-2.4.1.tgz#f230d13d9cc6b8699d3f26955b806d431b652fe9"
   integrity sha512-D+m/j8G54CQVE/2i0RmgCZQXNqNy7TGOl4KrqVZV4LsTYhjrWXmBHvfHM+mhyPs69QWfDEgW48Yy/zUwEbuMYA==
-  dependencies:
-    web-streams-polyfill "^2.0.6"
 
 connect@^3.6.0:
   version "3.6.6"


### PR DESCRIPTION
## Before this PR
Depending on old, 2.4.1 version of the conjure-client.

See https://github.com/palantir/conjure-typescript-runtime/pull/131 for details.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Bump dependency for conjure-client to 2.5.0.
==COMMIT_MSG==

## Possible downsides?
None?

