### PR TITLE
Mark incubating APIs as deprecated

### DIFF
--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -114,9 +114,9 @@ export function addIncubatingDocs(
 ): string[] | undefined {
     if (endpointDefinition.tags !== undefined && endpointDefinition.tags.indexOf("incubating") >= 0) {
         if (existingDocs === undefined) {
-            return [`@incubating`];
+            return [`@deprecated This function is incubating`];
         } else {
-            return [existingDocs + `\n@incubating`];
+            return [existingDocs + `\n@deprecated This function is incubating`];
         }
     }
     return existingDocs;


### PR DESCRIPTION
## Before this PR
By marking the endpoints as deprecated rather than incubating then frontend tooling will show the APIs differently, prompting the user more clearly.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mark incubating APIs as deprecated
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

