### PR TITLE
Add readonlyInterfaces generation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Options:
   --flavorizedAliases      Generates flavoured types for compatible aliases.                            [boolean] [default: false]
   --nodeCompatibleModules  Generate node compatible javascript                                          [boolean] [default: false]
   --rawSource              Generate raw source without any package metadata                             [boolean] [default: false]
-  --readonlyInterfaces     Generated interfaces have readonly properties and collections                [boolean] [default: false]  --productDependencies    Path to a file containing a list of product dependencies                                       [string]
+  --readonlyInterfaces     Generated interfaces have readonly properties and collections                [boolean] [default: false]
+  --productDependencies    Path to a file containing a list of product dependencies                                       [string]
 ```
 
 ## SemVer releases

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
   --flavorizedAliases      Generates flavoured types for compatible aliases.                            [boolean] [default: false]
   --nodeCompatibleModules  Generate node compatible javascript                                          [boolean] [default: false]
   --rawSource              Generate raw source without any package metadata                             [boolean] [default: false]
-  --productDependencies    Path to a file containing a list of product dependencies                                       [string]
+  --readonlyInterfaces     Generated interfaces have readonly properties and collections                [boolean] [default: false]  --productDependencies    Path to a file containing a list of product dependencies                                       [string]
 ```
 
 ## SemVer releases

--- a/changelog/@unreleased/pr-219.v2.yml
+++ b/changelog/@unreleased/pr-219.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: Default generated typescript is difficult to work with in a project
+    with strict readonly usage, often requiring casting from readonly arrays to mutable
+    arrays to make service calls. Added `--readonlyInterfaces` generation option to
+    emit types with readonly fields and arrays.
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/219

--- a/src/commands/generate/__tests__/errorGeneratorTest.ts
+++ b/src/commands/generate/__tests__/errorGeneratorTest.ts
@@ -21,10 +21,8 @@ import * as path from "path";
 import { directory } from "tempy";
 import { generateError } from "../errorGenerator";
 import { SimpleAst } from "../simpleAst";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
-
-const TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: true };
 
 describe("errorGenerator", () => {
     const expectedDir = path.join(__dirname, "./resources");
@@ -47,7 +45,7 @@ describe("errorGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
 
         const outFile1 = path.join(outDir, "errors/error.ts");
@@ -80,7 +78,7 @@ describe("errorGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
 
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "errors/primitiveError.ts");
@@ -102,7 +100,7 @@ describe("errorGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "errors/importError.ts");
     });

--- a/src/commands/generate/__tests__/generatorTest.ts
+++ b/src/commands/generate/__tests__/generatorTest.ts
@@ -33,11 +33,8 @@ import { generate } from "../generator";
 import { typeNameToFilePath } from "../simpleAst";
 import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { isFlavorizable } from "../utils";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
-
-const TYPE_GENERATION_FLAGS: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
 
 describe("generator", () => {
     let outDir: string;
@@ -64,7 +61,7 @@ describe("generator", () => {
                 extensions: {},
             },
             outDir,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile1 = path.join(outDir, "integration/myEnum.ts");
         const outFile2 = path.join(outDir, "integration/myEnum2.ts");
@@ -90,7 +87,7 @@ describe("generator", () => {
                 extensions: {},
             },
             outDir,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         expect(fs.existsSync(path.join(outDir, "integration-first/myEnum.ts"))).toBeTruthy();
         expect(fs.existsSync(path.join(outDir, "integration-second/myEnum2.ts"))).toBeTruthy();
@@ -127,9 +124,9 @@ describe("definitionTests", () => {
             await fs.mkdirp(outputDir);
             const conjureDefinition = await loadConjureDefinition(definitionFilePath);
 
-            await generate(conjureDefinition, outputDir, TYPE_GENERATION_FLAGS);
+            await generate(conjureDefinition, outputDir, DEFAULT_TYPE_GENERATION_FLAGS);
 
-            expectAllFilesAreTheSame(conjureDefinition, outputDir, actualDir, TYPE_GENERATION_FLAGS);
+            expectAllFilesAreTheSame(conjureDefinition, outputDir, actualDir, DEFAULT_TYPE_GENERATION_FLAGS);
         });
     }
 });

--- a/src/commands/generate/__tests__/generatorTest.ts
+++ b/src/commands/generate/__tests__/generatorTest.ts
@@ -33,7 +33,7 @@ import { generate } from "../generator";
 import { typeNameToFilePath } from "../simpleAst";
 import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { isFlavorizable } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
 
 describe("generator", () => {
@@ -107,45 +107,42 @@ export { integrationSecond };
 const irDir = path.join(__dirname, "../../../../build/ir-test-cases");
 const testCaseDir = path.join(__dirname, "resources/test-cases");
 const flavoredTestCaseDir = path.join(__dirname, "resources/flavored-test-cases");
+const readonlyTestCaseDir = path.join(__dirname, "resources/readonly-test-cases");
 
 describe("definitionTests", () => {
-    let tempDir: string;
-
-    beforeEach(() => {
-        tempDir = directory();
-    });
-
     for (const fileName of fs.readdirSync(irDir)) {
         const definitionFilePath = path.join(irDir, fileName);
         const paths = fileName.substring(0, fileName.lastIndexOf("."));
         const actualTestCaseDir = path.join(testCaseDir, paths);
         const actualFlavoredTestCaseDir = path.join(flavoredTestCaseDir, paths);
+        const actualReadonlyTestCaseDir = path.join(readonlyTestCaseDir, paths);
 
-        it(`${fileName} produces equivalent TypeScript`, async () => {
-            const outputDir = path.join(tempDir, paths);
-            await fs.mkdirp(outputDir);
-            const conjureDefinition = await loadConjureDefinition(definitionFilePath);
-
-            await generate(conjureDefinition, outputDir, DEFAULT_TYPE_GENERATION_FLAGS);
-
-            expectAllFilesAreTheSame(conjureDefinition, outputDir, actualTestCaseDir, DEFAULT_TYPE_GENERATION_FLAGS);
-        });
+        it(`${fileName} produces equivalent TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualTestCaseDir, DEFAULT_TYPE_GENERATION_FLAGS));
 
         // Not every test has a flavored version
         if (fs.existsSync(actualFlavoredTestCaseDir)) {
-            it(`${fileName} produces equivalent flavored TypeScript`, async () => {
-                const outputDir = path.join(tempDir, paths);
+            it(`${fileName} produces equivalent flavored TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualFlavoredTestCaseDir, FLAVORED_TYPE_GENERATION_FLAGS));
+        }
 
-                await fs.mkdirp(outputDir);
-                const conjureDefinition = await loadConjureDefinition(definitionFilePath);
-
-                await generate(conjureDefinition, outputDir, FLAVORED_TYPE_GENERATION_FLAGS);
-
-                expectAllFilesAreTheSame(conjureDefinition, outputDir, actualFlavoredTestCaseDir, FLAVORED_TYPE_GENERATION_FLAGS);
-            });
+        // Not every test has a readonly version
+        if (fs.existsSync(actualReadonlyTestCaseDir)) {
+            it(`${fileName} produces equivalent readonly TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualReadonlyTestCaseDir, READONLY_COLLECTION_TYPE_GENERATION_FLAGS));
         }
     }
 });
+
+function testGenerateAllFilesAreTheSame(definitionFilePath: string, paths: string, actualTestCaseDir: string, typeGenerationFlags: ITypeGenerationFlags) {
+    return async () => {
+        const tempDir = directory();
+        const outputDir = path.join(tempDir, paths);
+        await fs.mkdirp(outputDir);
+        const conjureDefinition = await loadConjureDefinition(definitionFilePath);
+
+        await generate(conjureDefinition, outputDir, typeGenerationFlags);
+
+        expectAllFilesAreTheSame(conjureDefinition, outputDir, actualTestCaseDir, typeGenerationFlags);
+    };
+}
 
 function expectAllFilesAreTheSame(
     definition: IConjureDefinition,

--- a/src/commands/generate/__tests__/generatorTest.ts
+++ b/src/commands/generate/__tests__/generatorTest.ts
@@ -33,7 +33,7 @@ import { generate } from "../generator";
 import { typeNameToFilePath } from "../simpleAst";
 import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { isFlavorizable } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
 
 describe("generator", () => {
@@ -106,6 +106,7 @@ export { integrationSecond };
 
 const irDir = path.join(__dirname, "../../../../build/ir-test-cases");
 const testCaseDir = path.join(__dirname, "resources/test-cases");
+const flavoredTestCaseDir = path.join(__dirname, "resources/flavored-test-cases");
 
 describe("definitionTests", () => {
     let tempDir: string;
@@ -115,19 +116,34 @@ describe("definitionTests", () => {
     });
 
     for (const fileName of fs.readdirSync(irDir)) {
-        it(`${fileName} produces equivalent TypeScript`, async () => {
-            const definitionFilePath = path.join(irDir, fileName);
-            const paths = fileName.substring(0, fileName.lastIndexOf("."));
-            const actualDir = path.join(testCaseDir, paths);
-            const outputDir = path.join(tempDir, paths);
+        const definitionFilePath = path.join(irDir, fileName);
+        const paths = fileName.substring(0, fileName.lastIndexOf("."));
+        const actualTestCaseDir = path.join(testCaseDir, paths);
+        const actualFlavoredTestCaseDir = path.join(flavoredTestCaseDir, paths);
 
+        it(`${fileName} produces equivalent TypeScript`, async () => {
+            const outputDir = path.join(tempDir, paths);
             await fs.mkdirp(outputDir);
             const conjureDefinition = await loadConjureDefinition(definitionFilePath);
 
             await generate(conjureDefinition, outputDir, DEFAULT_TYPE_GENERATION_FLAGS);
 
-            expectAllFilesAreTheSame(conjureDefinition, outputDir, actualDir, DEFAULT_TYPE_GENERATION_FLAGS);
+            expectAllFilesAreTheSame(conjureDefinition, outputDir, actualTestCaseDir, DEFAULT_TYPE_GENERATION_FLAGS);
         });
+
+        // Not every test has a flavored version
+        if (fs.existsSync(actualFlavoredTestCaseDir)) {
+            it(`${fileName} produces equivalent flavored TypeScript`, async () => {
+                const outputDir = path.join(tempDir, paths);
+
+                await fs.mkdirp(outputDir);
+                const conjureDefinition = await loadConjureDefinition(definitionFilePath);
+
+                await generate(conjureDefinition, outputDir, FLAVORED_TYPE_GENERATION_FLAGS);
+
+                expectAllFilesAreTheSame(conjureDefinition, outputDir, actualFlavoredTestCaseDir, FLAVORED_TYPE_GENERATION_FLAGS);
+            });
+        }
     }
 });
 

--- a/src/commands/generate/__tests__/generatorTest.ts
+++ b/src/commands/generate/__tests__/generatorTest.ts
@@ -33,7 +33,7 @@ import { generate } from "../generator";
 import { typeNameToFilePath } from "../simpleAst";
 import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { isFlavorizable } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
 
 describe("generator", () => {
@@ -126,7 +126,7 @@ describe("definitionTests", () => {
 
         // Not every test has a readonly version
         if (fs.existsSync(actualReadonlyTestCaseDir)) {
-            it(`${fileName} produces equivalent readonly TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualReadonlyTestCaseDir, READONLY_COLLECTION_TYPE_GENERATION_FLAGS));
+            it(`${fileName} produces equivalent readonly TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualReadonlyTestCaseDir, READONLY_TYPE_GENERATION_FLAGS));
         }
     }
 });

--- a/src/commands/generate/__tests__/importsTest.ts
+++ b/src/commands/generate/__tests__/importsTest.ts
@@ -17,13 +17,11 @@
 
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { ImportsVisitor, sortImports } from "../imports";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { createHashableTypeName } from "../utils";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { foreignObject, importsLocalObject as localObject } from "./testTypesGeneratorTest";
 
-const GENERATION_FLAGS_TO_USE_FOR_IMPORTS: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
+const GENERATION_FLAGS_TO_USE_FOR_IMPORTS = DEFAULT_TYPE_GENERATION_FLAGS;
 
 describe("imports", () => {
     const currType = {

--- a/src/commands/generate/__tests__/importsTest.ts
+++ b/src/commands/generate/__tests__/importsTest.ts
@@ -18,10 +18,10 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { ImportsVisitor, sortImports } from "../imports";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { foreignObject, importsLocalObject as localObject } from "./testTypesGeneratorTest";
 
-const GENERATION_FLAGS_TO_USE_FOR_IMPORTS = DEFAULT_TYPE_GENERATION_FLAGS;
+const GENERATION_FLAGS_TO_USE_FOR_IMPORTS = FLAVORED_TYPE_GENERATION_FLAGS;
 
 describe("imports", () => {
     const currType = {

--- a/src/commands/generate/__tests__/resources/constants.ts
+++ b/src/commands/generate/__tests__/resources/constants.ts
@@ -1,7 +1,7 @@
 import { ITypeGenerationFlags } from "../../typeGenerationFlags";
 
-export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false, readonlyInterfaces: false };
+export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyInterfaces: false };
 
 export const FLAVORED_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, flavorizedAliases: true };
 
-export const READONLY_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true, readonlyInterfaces: true };
+export const READONLY_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyInterfaces: true };

--- a/src/commands/generate/__tests__/resources/constants.ts
+++ b/src/commands/generate/__tests__/resources/constants.ts
@@ -1,0 +1,7 @@
+import { ITypeGenerationFlags } from "../../typeGenerationFlags";
+
+export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false };
+
+export const FLAVORED_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, flavorizedAliases: true };
+
+export const READONLY_COLLECTION_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true };

--- a/src/commands/generate/__tests__/resources/constants.ts
+++ b/src/commands/generate/__tests__/resources/constants.ts
@@ -1,7 +1,7 @@
 import { ITypeGenerationFlags } from "../../typeGenerationFlags";
 
-export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false };
+export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false, readonlyInterfaces: false };
 
 export const FLAVORED_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, flavorizedAliases: true };
 
-export const READONLY_COLLECTION_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true };
+export const READONLY_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true, readonlyInterfaces: true };

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
@@ -1,5 +1,6 @@
 import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
 import { IDataset } from "../product-datasets/dataset";
+import { IAliasedString } from "../product/aliasedString";
 import { ICreateDatasetRequest } from "../product/createDatasetRequest";
 import { IHttpApiBridge } from "conjure-client";
 
@@ -23,7 +24,7 @@ export interface ITestService {
     getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
     getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
     maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null>;
-    getAliasedString(datasetRid: string): Promise<string>;
+    getAliasedString(datasetRid: string): Promise<IAliasedString>;
     uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
     uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
     getBranches(datasetRid: string): Promise<Array<string>>;
@@ -152,8 +153,8 @@ export class TestService {
         );
     }
 
-    public getAliasedString(datasetRid: string): Promise<string> {
-        return this.bridge.call<string>(
+    public getAliasedString(datasetRid: string): Promise<IAliasedString> {
+        return this.bridge.call<IAliasedString>(
             "TestService",
             "getAliasedString",
             "GET",

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product-datasets/backingFileSystem.ts
@@ -1,0 +1,8 @@
+export interface IBackingFileSystem {
+    /**
+     * The name by which this file system is identified.
+     */
+    'fileSystemId': string;
+    'baseUri': string;
+    'configuration': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product-datasets/dataset.ts
@@ -1,0 +1,7 @@
+export interface IDataset {
+    'fileSystemId': string;
+    /**
+     * Uniquely identifies this dataset.
+     */
+    'rid': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product/aliasedString.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product/aliasedString.ts
@@ -1,0 +1,4 @@
+export type IAliasedString = string & {
+    __conjure_type?: "AliasedString",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/product/createDatasetRequest.ts
@@ -1,0 +1,4 @@
+export interface ICreateDatasetRequest {
+    'fileSystemId': string;
+    'path': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/aliasAsMapKeyExample.ts
@@ -1,0 +1,17 @@
+import { IBearerTokenAliasExample } from "./bearerTokenAliasExample";
+import { IIntegerAliasExample } from "./integerAliasExample";
+import { IManyFieldExample } from "./manyFieldExample";
+import { IRidAliasExample } from "./ridAliasExample";
+import { ISafeLongAliasExample } from "./safeLongAliasExample";
+import { IStringAliasExample } from "./stringAliasExample";
+import { IUuidAliasExample } from "./uuidAliasExample";
+
+export interface IAliasAsMapKeyExample {
+    'strings': { [key: IStringAliasExample]: IManyFieldExample };
+    'rids': { [key: IRidAliasExample]: IManyFieldExample };
+    'bearertokens': { [key: IBearerTokenAliasExample]: IManyFieldExample };
+    'integers': { [key: IIntegerAliasExample]: IManyFieldExample };
+    'safelongs': { [key: ISafeLongAliasExample]: IManyFieldExample };
+    'datetimes': { [key: string]: IManyFieldExample };
+    'uuids': { [key: IUuidAliasExample]: IManyFieldExample };
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/anyExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyExample {
+    'any': any;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/anyMapExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyMapExample {
+    'items': { [key: string]: any };
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerAliasExample = string & {
+    __conjure_type?: "BearerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerTokenAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerTokenAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerTokenAliasExample = string & {
+    __conjure_type?: "BearerTokenAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/bearerTokenExample.ts
@@ -1,0 +1,3 @@
+export interface IBearerTokenExample {
+    'bearerTokenValue': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/booleanAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/booleanAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBooleanAliasExample = boolean & {
+    __conjure_type?: "BooleanAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/booleanExample.ts
@@ -1,0 +1,3 @@
+export interface IBooleanExample {
+    'coin': boolean;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/covariantListExample.ts
@@ -1,0 +1,4 @@
+export interface ICovariantListExample {
+    'items': Array<any>;
+    'externalItems': Array<string>;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/covariantOptionalExample.ts
@@ -1,0 +1,3 @@
+export interface ICovariantOptionalExample {
+    'item'?: any | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/dateTimeExample.ts
@@ -1,0 +1,3 @@
+export interface IDateTimeExample {
+    'datetime': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedEnumExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedEnumExample.ts
@@ -1,0 +1,27 @@
+export namespace DeprecatedEnumExample {
+    export type ONE = "ONE";
+    /**
+     * @deprecated use ONE
+     */
+    export type OLD_ONE = "OLD_ONE";
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated use ONE
+     */
+    export type OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE";
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated should use ONE
+     * 
+     */
+    export type OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE";
+
+    export const ONE = "ONE" as "ONE";
+    export const OLD_ONE = "OLD_ONE" as "OLD_ONE";
+    export const OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE" as "OLD_DEPRECATED_ONE";
+    export const OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE" as "OLD_DOCUMENTED_ONE";
+}
+
+export type DeprecatedEnumExample = keyof typeof DeprecatedEnumExample;

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedFieldExample.ts
@@ -1,0 +1,20 @@
+export interface IDeprecatedFieldExample {
+    'one': string;
+    /**
+     * @deprecated use ONE
+     */
+    'deprecatedOne': string;
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated use ONE
+     */
+    'documentedDeprecatedOne': string;
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated should use ONE
+     * 
+     */
+    'deprecatedWithinDocumentOne': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedUnion.ts
@@ -1,0 +1,92 @@
+export interface IDeprecatedUnion_Good {
+    'good': string;
+    'type': "good";
+}
+
+/**
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGood {
+    'noGood': string;
+    'type': "noGood";
+}
+
+/**
+ * this is no good
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGoodDoc {
+    'noGoodDoc': string;
+    'type': "noGoodDoc";
+}
+
+function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
+    return (obj.type === "good");
+}
+
+function good(obj: string): IDeprecatedUnion_Good {
+    return {
+        good: obj,
+        type: "good",
+    };
+}
+
+function isNoGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGood {
+    return (obj.type === "noGood");
+}
+
+/**
+ * @deprecated use good
+ */
+function noGood(obj: string): IDeprecatedUnion_NoGood {
+    return {
+        noGood: obj,
+        type: "noGood",
+    };
+}
+
+function isNoGoodDoc(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGoodDoc {
+    return (obj.type === "noGoodDoc");
+}
+
+/**
+ * @deprecated use good
+ */
+function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
+    return {
+        noGoodDoc: obj,
+        type: "noGoodDoc",
+    };
+}
+
+export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
+
+export interface IDeprecatedUnionVisitor<T> {
+    'good': (obj: string) => T;
+    'noGood': (obj: string) => T;
+    'noGoodDoc': (obj: string) => T;
+    'unknown': (obj: IDeprecatedUnion) => T;
+}
+
+function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
+    if (isGood(obj)) {
+        return visitor.good(obj.good);
+    }
+    if (isNoGood(obj)) {
+        return visitor.noGood(obj.noGood);
+    }
+    if (isNoGoodDoc(obj)) {
+        return visitor.noGoodDoc(obj.noGoodDoc);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IDeprecatedUnion = {
+    isGood: isGood,
+    good: good,
+    isNoGood: isNoGood,
+    noGood: noGood,
+    isNoGoodDoc: isNoGoodDoc,
+    noGoodDoc: noGoodDoc,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/doubleAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/doubleAliasExample.ts
@@ -1,0 +1,4 @@
+export type IDoubleAliasExample = number | "NaN" & {
+    __conjure_type?: "DoubleAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/doubleExample.ts
@@ -1,0 +1,3 @@
+export interface IDoubleExample {
+    'doubleValue': number | "NaN";
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyEnum.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyEnum.ts
@@ -1,0 +1,3 @@
+export const EmptyEnum = {};
+
+export type EmptyEnum = void;

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyObjectExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyObjectExample.ts
@@ -1,0 +1,2 @@
+export interface IEmptyObjectExample {
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/enumExample.ts
@@ -1,0 +1,18 @@
+/**
+ * This enumerates the numbers 1:2 also 100.
+ * 
+ */
+export namespace EnumExample {
+    export type ONE = "ONE";
+    export type TWO = "TWO";
+    /**
+     * Value of 100.
+     */
+    export type ONE_HUNDRED = "ONE_HUNDRED";
+
+    export const ONE = "ONE" as "ONE";
+    export const TWO = "TWO" as "TWO";
+    export const ONE_HUNDRED = "ONE_HUNDRED" as "ONE_HUNDRED";
+}
+
+export type EnumExample = keyof typeof EnumExample;

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/enumFieldExample.ts
@@ -1,0 +1,5 @@
+import { EnumExample } from "./enumExample";
+
+export interface IEnumFieldExample {
+    'enum': EnumExample;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/externalLongExample.ts
@@ -1,0 +1,5 @@
+export interface IExternalLongExample {
+    'externalLong': number;
+    'optionalExternalLong'?: number | null;
+    'listExternalLong': Array<number>;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/integerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/integerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IIntegerAliasExample = number & {
+    __conjure_type?: "IntegerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/integerExample.ts
@@ -1,0 +1,3 @@
+export interface IIntegerExample {
+    'integer': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/listExample.ts
@@ -1,0 +1,5 @@
+export interface IListExample {
+    'items': Array<string>;
+    'primitiveItems': Array<number>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/manyFieldExample.ts
@@ -1,3 +1,5 @@
+import { IStringAliasExample } from "./stringAliasExample";
+
 export interface IManyFieldExample {
     /**
      * docs for string field
@@ -30,5 +32,5 @@ export interface IManyFieldExample {
     /**
      * docs for alias field
      */
-    'alias': string;
+    'alias': IStringAliasExample;
 }

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/mapExample.ts
@@ -1,0 +1,3 @@
+export interface IMapExample {
+    'items': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/primitiveOptionalsExample.ts
@@ -1,0 +1,9 @@
+export interface IPrimitiveOptionalsExample {
+    'num'?: number | "NaN" | null;
+    'bool'?: boolean | null;
+    'integer'?: number | null;
+    'safelong'?: number | null;
+    'rid'?: string | null;
+    'bearertoken'?: string | null;
+    'uuid'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/reservedKeyExample.ts
@@ -1,0 +1,7 @@
+export interface IReservedKeyExample {
+    'package': string;
+    'interface': string;
+    'field-name-with-dashes': string;
+    'primitve-field-name-with-dashes': number;
+    'memoizedHashCode': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/ridAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/ridAliasExample.ts
@@ -1,0 +1,4 @@
+export type IRidAliasExample = string & {
+    __conjure_type?: "RidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/ridExample.ts
@@ -1,0 +1,3 @@
+export interface IRidExample {
+    'ridValue': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/safeLongAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/safeLongAliasExample.ts
@@ -1,0 +1,4 @@
+export type ISafeLongAliasExample = number & {
+    __conjure_type?: "SafeLongAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/safeLongExample.ts
@@ -1,0 +1,3 @@
+export interface ISafeLongExample {
+    'safeLongValue': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/setExample.ts
@@ -1,0 +1,4 @@
+export interface ISetExample {
+    'items': Array<string>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/simpleEnum.ts
@@ -1,0 +1,7 @@
+export namespace SimpleEnum {
+    export type VALUE = "VALUE";
+
+    export const VALUE = "VALUE" as "VALUE";
+}
+
+export type SimpleEnum = keyof typeof SimpleEnum;

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/singleUnion.ts
@@ -1,0 +1,35 @@
+export interface ISingleUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): ISingleUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+export type ISingleUnion = ISingleUnion_Foo;
+
+export interface ISingleUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'unknown': (obj: ISingleUnion) => T;
+}
+
+function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    return visitor.unknown(obj);
+}
+
+export const ISingleUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringAliasExample.ts
@@ -1,0 +1,4 @@
+export type IStringAliasExample = string & {
+    __conjure_type?: "StringAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringAliasOne.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringAliasOne.ts
@@ -1,0 +1,4 @@
+export type IStringAliasOne = string & {
+    __conjure_type?: "StringAliasOne",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/stringExample.ts
@@ -1,0 +1,3 @@
+export interface IStringExample {
+    'string': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/union.ts
@@ -1,0 +1,79 @@
+export interface IUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+export interface IUnion_Bar {
+    'bar': number;
+    'type': "bar";
+}
+
+export interface IUnion_Baz {
+    'baz': number;
+    'type': "baz";
+}
+
+function isFoo(obj: IUnion): obj is IUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): IUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+function isBar(obj: IUnion): obj is IUnion_Bar {
+    return (obj.type === "bar");
+}
+
+function bar(obj: number): IUnion_Bar {
+    return {
+        bar: obj,
+        type: "bar",
+    };
+}
+
+function isBaz(obj: IUnion): obj is IUnion_Baz {
+    return (obj.type === "baz");
+}
+
+function baz(obj: number): IUnion_Baz {
+    return {
+        baz: obj,
+        type: "baz",
+    };
+}
+
+export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
+
+export interface IUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'bar': (obj: number) => T;
+    'baz': (obj: number) => T;
+    'unknown': (obj: IUnion) => T;
+}
+
+function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    if (isBar(obj)) {
+        return visitor.bar(obj.bar);
+    }
+    if (isBaz(obj)) {
+        return visitor.baz(obj.baz);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    isBar: isBar,
+    bar: bar,
+    isBaz: isBaz,
+    baz: baz,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/unionTypeExample.ts
@@ -1,0 +1,175 @@
+import { IStringExample } from "./stringExample";
+
+/**
+ * Docs for when UnionTypeExample is of type StringExample.
+ */
+export interface IUnionTypeExample_StringExample {
+    'stringExample': IStringExample;
+    'type': "stringExample";
+}
+
+export interface IUnionTypeExample_Set {
+    'set': Array<string>;
+    'type': "set";
+}
+
+export interface IUnionTypeExample_ThisFieldIsAnInteger {
+    'thisFieldIsAnInteger': number;
+    'type': "thisFieldIsAnInteger";
+}
+
+export interface IUnionTypeExample_AlsoAnInteger {
+    'alsoAnInteger': number;
+    'type': "alsoAnInteger";
+}
+
+export interface IUnionTypeExample_If {
+    'if': number;
+    'type': "if";
+}
+
+export interface IUnionTypeExample_New {
+    'new': number;
+    'type': "new";
+}
+
+export interface IUnionTypeExample_Interface {
+    'interface': number;
+    'type': "interface";
+}
+
+function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
+    return (obj.type === "stringExample");
+}
+
+function stringExample(obj: IStringExample): IUnionTypeExample_StringExample {
+    return {
+        stringExample: obj,
+        type: "stringExample",
+    };
+}
+
+function isSet(obj: IUnionTypeExample): obj is IUnionTypeExample_Set {
+    return (obj.type === "set");
+}
+
+function set(obj: Array<string>): IUnionTypeExample_Set {
+    return {
+        set: obj,
+        type: "set",
+    };
+}
+
+function isThisFieldIsAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_ThisFieldIsAnInteger {
+    return (obj.type === "thisFieldIsAnInteger");
+}
+
+function thisFieldIsAnInteger(obj: number): IUnionTypeExample_ThisFieldIsAnInteger {
+    return {
+        thisFieldIsAnInteger: obj,
+        type: "thisFieldIsAnInteger",
+    };
+}
+
+function isAlsoAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_AlsoAnInteger {
+    return (obj.type === "alsoAnInteger");
+}
+
+function alsoAnInteger(obj: number): IUnionTypeExample_AlsoAnInteger {
+    return {
+        alsoAnInteger: obj,
+        type: "alsoAnInteger",
+    };
+}
+
+function isIf(obj: IUnionTypeExample): obj is IUnionTypeExample_If {
+    return (obj.type === "if");
+}
+
+function if_(obj: number): IUnionTypeExample_If {
+    return {
+        if: obj,
+        type: "if",
+    };
+}
+
+function isNew(obj: IUnionTypeExample): obj is IUnionTypeExample_New {
+    return (obj.type === "new");
+}
+
+function new_(obj: number): IUnionTypeExample_New {
+    return {
+        new: obj,
+        type: "new",
+    };
+}
+
+function isInterface(obj: IUnionTypeExample): obj is IUnionTypeExample_Interface {
+    return (obj.type === "interface");
+}
+
+function interface_(obj: number): IUnionTypeExample_Interface {
+    return {
+        interface: obj,
+        type: "interface",
+    };
+}
+
+/**
+ * A type which can either be a StringExample, a set of strings, or an integer.
+ */
+export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
+
+export interface IUnionTypeExampleVisitor<T> {
+    'stringExample': (obj: IStringExample) => T;
+    'set': (obj: Array<string>) => T;
+    'thisFieldIsAnInteger': (obj: number) => T;
+    'alsoAnInteger': (obj: number) => T;
+    'if': (obj: number) => T;
+    'new': (obj: number) => T;
+    'interface': (obj: number) => T;
+    'unknown': (obj: IUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
+    if (isStringExample(obj)) {
+        return visitor.stringExample(obj.stringExample);
+    }
+    if (isSet(obj)) {
+        return visitor.set(obj.set);
+    }
+    if (isThisFieldIsAnInteger(obj)) {
+        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+    }
+    if (isAlsoAnInteger(obj)) {
+        return visitor.alsoAnInteger(obj.alsoAnInteger);
+    }
+    if (isIf(obj)) {
+        return visitor.if(obj.if);
+    }
+    if (isNew(obj)) {
+        return visitor.new(obj.new);
+    }
+    if (isInterface(obj)) {
+        return visitor.interface(obj.interface);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnionTypeExample = {
+    isStringExample: isStringExample,
+    stringExample: stringExample,
+    isSet: isSet,
+    set: set,
+    isThisFieldIsAnInteger: isThisFieldIsAnInteger,
+    thisFieldIsAnInteger: thisFieldIsAnInteger,
+    isAlsoAnInteger: isAlsoAnInteger,
+    alsoAnInteger: alsoAnInteger,
+    isIf: isIf,
+    if_: if_,
+    isNew: isNew,
+    new_: new_,
+    isInterface: isInterface,
+    interface_: interface_,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/uuidAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/uuidAliasExample.ts
@@ -1,0 +1,4 @@
+export type IUuidAliasExample = string & {
+    __conjure_type?: "UuidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/uuidExample.ts
@@ -1,0 +1,3 @@
+export interface IUuidExample {
+    'uuid': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
@@ -1,0 +1,405 @@
+import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
+import { IDataset } from "../product-datasets/dataset";
+import { ICreateDatasetRequest } from "../product/createDatasetRequest";
+import { IHttpApiBridge } from "conjure-client";
+
+/**
+ * Constant reference to `undefined` that we expect to get minified and therefore reduce total code size
+ */
+const __undefined: undefined = undefined;
+
+/**
+ * A Markdown description of the service.
+ * 
+ */
+export interface ITestService {
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     * 
+     */
+    getFileSystems(): Promise<{ readonly [key: string]: IBackingFileSystem }>;
+    createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
+    getDataset(datasetRid: string): Promise<IDataset | null>;
+    getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null>;
+    getAliasedString(datasetRid: string): Promise<string>;
+    uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    getBranches(datasetRid: string): Promise<ReadonlyArray<string>>;
+    /**
+     * Gets all branches of this dataset.
+     * 
+     * @deprecated use getBranches instead
+     */
+    getBranchesDeprecated(datasetRid: string): Promise<ReadonlyArray<string>>;
+    resolveBranch(datasetRid: string, branch: string): Promise<string | null>;
+    testParam(datasetRid: string): Promise<string | null>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
+    testBoolean(): Promise<boolean>;
+    testDouble(): Promise<number | "NaN">;
+    testInteger(): Promise<number>;
+    testPostOptional(maybeString?: string | null): Promise<string | null>;
+    testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void>;
+}
+
+export class TestService {
+    constructor(private bridge: IHttpApiBridge) {
+    }
+
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     * 
+     */
+    public getFileSystems(): Promise<{ readonly [key: string]: IBackingFileSystem }> {
+        return this.bridge.call<{ readonly [key: string]: IBackingFileSystem }>(
+            "TestService",
+            "getFileSystems",
+            "GET",
+            "/catalog/fileSystems",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+        return this.bridge.call<IDataset>(
+            "TestService",
+            "createDataset",
+            "POST",
+            "/catalog/datasets",
+            request,
+            {
+                "Test-Header": testHeaderArg,
+            },
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public getDataset(datasetRid: string): Promise<IDataset | null> {
+        return this.bridge.call<IDataset | null>(
+            "TestService",
+            "getDataset",
+            "GET",
+            "/catalog/datasets/{datasetRid}",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    public getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(
+            "TestService",
+            "getRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(
+            "TestService",
+            "getAliasedRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+        return this.bridge.call<ReadableStream<Uint8Array> | null>(
+            "TestService",
+            "maybeGetRawData",
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-maybe",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedString(datasetRid: string): Promise<string> {
+        return this.bridge.call<string>(
+            "TestService",
+            "getAliasedString",
+            "GET",
+            "/catalog/datasets/{datasetRid}/string-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    public uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(
+            "TestService",
+            "uploadRawData",
+            "POST",
+            "/catalog/datasets/upload-raw",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+            __undefined
+        );
+    }
+
+    public uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(
+            "TestService",
+            "uploadAliasedRawData",
+            "POST",
+            "/catalog/datasets/upload-raw-aliased",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+            __undefined
+        );
+    }
+
+    public getBranches(datasetRid: string): Promise<ReadonlyArray<string>> {
+        return this.bridge.call<ReadonlyArray<string>>(
+            "TestService",
+            "getBranches",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    /**
+     * Gets all branches of this dataset.
+     * 
+     * @deprecated use getBranches instead
+     */
+    public getBranchesDeprecated(datasetRid: string): Promise<ReadonlyArray<string>> {
+        return this.bridge.call<ReadonlyArray<string>>(
+            "TestService",
+            "getBranchesDeprecated",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branchesDeprecated",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    public resolveBranch(datasetRid: string, branch: string): Promise<string | null> {
+        return this.bridge.call<string | null>(
+            "TestService",
+            "resolveBranch",
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+
+                branch,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testParam(datasetRid: string): Promise<string | null> {
+        return this.bridge.call<string | null>(
+            "TestService",
+            "testParam",
+            "GET",
+            "/catalog/datasets/{datasetRid}/testParam",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+        return this.bridge.call<number>(
+            "TestService",
+            "testQueryParams",
+            "POST",
+            "/catalog/test-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+        return this.bridge.call<void>(
+            "TestService",
+            "testNoResponseQueryParams",
+            "POST",
+            "/catalog/test-no-response-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testBoolean(): Promise<boolean> {
+        return this.bridge.call<boolean>(
+            "TestService",
+            "testBoolean",
+            "GET",
+            "/catalog/boolean",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testDouble(): Promise<number | "NaN"> {
+        return this.bridge.call<number | "NaN">(
+            "TestService",
+            "testDouble",
+            "GET",
+            "/catalog/double",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testInteger(): Promise<number> {
+        return this.bridge.call<number>(
+            "TestService",
+            "testInteger",
+            "GET",
+            "/catalog/integer",
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testPostOptional(maybeString?: string | null): Promise<string | null> {
+        return this.bridge.call<string | null>(
+            "TestService",
+            "testPostOptional",
+            "POST",
+            "/catalog/optional",
+            maybeString,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+
+    public testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+        return this.bridge.call<void>(
+            "TestService",
+            "testOptionalIntegerAndDouble",
+            "GET",
+            "/catalog/optional-integer-double",
+            __undefined,
+            __undefined,
+            {
+                "maybeInteger": maybeInteger,
+
+                "maybeDouble": maybeDouble,
+            },
+            __undefined,
+            __undefined,
+            __undefined
+        );
+    }
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
@@ -2,7 +2,7 @@ export interface IBackingFileSystem {
     /**
      * The name by which this file system is identified.
      */
-    'fileSystemId': string;
-    'baseUri': string;
-    'configuration': { readonly [key: string]: string };
+    readonly 'fileSystemId': string;
+    readonly 'baseUri': string;
+    readonly 'configuration': { readonly [key: string]: string };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
@@ -1,0 +1,8 @@
+export interface IBackingFileSystem {
+    /**
+     * The name by which this file system is identified.
+     */
+    'fileSystemId': string;
+    'baseUri': string;
+    'configuration': { readonly [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
@@ -1,7 +1,7 @@
 export interface IDataset {
-    'fileSystemId': string;
+    readonly 'fileSystemId': string;
     /**
      * Uniquely identifies this dataset.
      */
-    'rid': string;
+    readonly 'rid': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
@@ -1,0 +1,7 @@
+export interface IDataset {
+    'fileSystemId': string;
+    /**
+     * Uniquely identifies this dataset.
+     */
+    'rid': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/aliasedString.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/aliasedString.ts
@@ -1,0 +1,4 @@
+export type IAliasedString = string & {
+    __conjure_type?: "AliasedString",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
@@ -1,0 +1,4 @@
+export interface ICreateDatasetRequest {
+    'fileSystemId': string;
+    'path': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
@@ -1,4 +1,4 @@
 export interface ICreateDatasetRequest {
-    'fileSystemId': string;
-    'path': string;
+    readonly 'fileSystemId': string;
+    readonly 'path': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
@@ -1,0 +1,11 @@
+import { IManyFieldExample } from "./manyFieldExample";
+
+export interface IAliasAsMapKeyExample {
+    'strings': { readonly [key: string]: IManyFieldExample };
+    'rids': { readonly [key: string]: IManyFieldExample };
+    'bearertokens': { readonly [key: string]: IManyFieldExample };
+    'integers': { readonly [key: string]: IManyFieldExample };
+    'safelongs': { readonly [key: string]: IManyFieldExample };
+    'datetimes': { readonly [key: string]: IManyFieldExample };
+    'uuids': { readonly [key: string]: IManyFieldExample };
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
@@ -1,11 +1,11 @@
 import { IManyFieldExample } from "./manyFieldExample";
 
 export interface IAliasAsMapKeyExample {
-    'strings': { readonly [key: string]: IManyFieldExample };
-    'rids': { readonly [key: string]: IManyFieldExample };
-    'bearertokens': { readonly [key: string]: IManyFieldExample };
-    'integers': { readonly [key: string]: IManyFieldExample };
-    'safelongs': { readonly [key: string]: IManyFieldExample };
-    'datetimes': { readonly [key: string]: IManyFieldExample };
-    'uuids': { readonly [key: string]: IManyFieldExample };
+    readonly 'strings': { readonly [key: string]: IManyFieldExample };
+    readonly 'rids': { readonly [key: string]: IManyFieldExample };
+    readonly 'bearertokens': { readonly [key: string]: IManyFieldExample };
+    readonly 'integers': { readonly [key: string]: IManyFieldExample };
+    readonly 'safelongs': { readonly [key: string]: IManyFieldExample };
+    readonly 'datetimes': { readonly [key: string]: IManyFieldExample };
+    readonly 'uuids': { readonly [key: string]: IManyFieldExample };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyExample {
+    'any': any;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
@@ -1,3 +1,3 @@
 export interface IAnyExample {
-    'any': any;
+    readonly 'any': any;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyMapExample {
+    'items': { readonly [key: string]: any };
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
@@ -1,3 +1,3 @@
 export interface IAnyMapExample {
-    'items': { readonly [key: string]: any };
+    readonly 'items': { readonly [key: string]: any };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerAliasExample = string & {
+    __conjure_type?: "BearerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerTokenAliasExample = string & {
+    __conjure_type?: "BearerTokenAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
@@ -1,0 +1,3 @@
+export interface IBearerTokenExample {
+    'bearerTokenValue': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
@@ -1,3 +1,3 @@
 export interface IBearerTokenExample {
-    'bearerTokenValue': string;
+    readonly 'bearerTokenValue': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': string;
+    readonly 'binary': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBooleanAliasExample = boolean & {
+    __conjure_type?: "BooleanAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
@@ -1,3 +1,3 @@
 export interface IBooleanExample {
-    'coin': boolean;
+    readonly 'coin': boolean;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
@@ -1,0 +1,3 @@
+export interface IBooleanExample {
+    'coin': boolean;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
@@ -1,4 +1,4 @@
 export interface ICovariantListExample {
-    'items': ReadonlyArray<any>;
-    'externalItems': ReadonlyArray<string>;
+    readonly 'items': ReadonlyArray<any>;
+    readonly 'externalItems': ReadonlyArray<string>;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
@@ -1,0 +1,4 @@
+export interface ICovariantListExample {
+    'items': ReadonlyArray<any>;
+    'externalItems': ReadonlyArray<string>;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
@@ -1,0 +1,3 @@
+export interface ICovariantOptionalExample {
+    'item'?: any | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
@@ -1,3 +1,3 @@
 export interface ICovariantOptionalExample {
-    'item'?: any | null;
+    readonly 'item'?: any | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
@@ -1,0 +1,3 @@
+export interface IDateTimeExample {
+    'datetime': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
@@ -1,3 +1,3 @@
 export interface IDateTimeExample {
-    'datetime': string;
+    readonly 'datetime': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedEnumExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedEnumExample.ts
@@ -1,0 +1,27 @@
+export namespace DeprecatedEnumExample {
+    export type ONE = "ONE";
+    /**
+     * @deprecated use ONE
+     */
+    export type OLD_ONE = "OLD_ONE";
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated use ONE
+     */
+    export type OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE";
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated should use ONE
+     * 
+     */
+    export type OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE";
+
+    export const ONE = "ONE" as "ONE";
+    export const OLD_ONE = "OLD_ONE" as "OLD_ONE";
+    export const OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE" as "OLD_DEPRECATED_ONE";
+    export const OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE" as "OLD_DOCUMENTED_ONE";
+}
+
+export type DeprecatedEnumExample = keyof typeof DeprecatedEnumExample;

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
@@ -1,20 +1,20 @@
 export interface IDeprecatedFieldExample {
-    'one': string;
+    readonly 'one': string;
     /**
      * @deprecated use ONE
      */
-    'deprecatedOne': string;
+    readonly 'deprecatedOne': string;
     /**
      * You should no longer use this
      * 
      * @deprecated use ONE
      */
-    'documentedDeprecatedOne': string;
+    readonly 'documentedDeprecatedOne': string;
     /**
      * You should no longer use this
      * 
      * @deprecated should use ONE
      * 
      */
-    'deprecatedWithinDocumentOne': string;
+    readonly 'deprecatedWithinDocumentOne': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
@@ -1,0 +1,20 @@
+export interface IDeprecatedFieldExample {
+    'one': string;
+    /**
+     * @deprecated use ONE
+     */
+    'deprecatedOne': string;
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated use ONE
+     */
+    'documentedDeprecatedOne': string;
+    /**
+     * You should no longer use this
+     * 
+     * @deprecated should use ONE
+     * 
+     */
+    'deprecatedWithinDocumentOne': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
@@ -1,0 +1,92 @@
+export interface IDeprecatedUnion_Good {
+    'good': string;
+    'type': "good";
+}
+
+/**
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGood {
+    'noGood': string;
+    'type': "noGood";
+}
+
+/**
+ * this is no good
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGoodDoc {
+    'noGoodDoc': string;
+    'type': "noGoodDoc";
+}
+
+function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
+    return (obj.type === "good");
+}
+
+function good(obj: string): IDeprecatedUnion_Good {
+    return {
+        good: obj,
+        type: "good",
+    };
+}
+
+function isNoGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGood {
+    return (obj.type === "noGood");
+}
+
+/**
+ * @deprecated use good
+ */
+function noGood(obj: string): IDeprecatedUnion_NoGood {
+    return {
+        noGood: obj,
+        type: "noGood",
+    };
+}
+
+function isNoGoodDoc(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGoodDoc {
+    return (obj.type === "noGoodDoc");
+}
+
+/**
+ * @deprecated use good
+ */
+function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
+    return {
+        noGoodDoc: obj,
+        type: "noGoodDoc",
+    };
+}
+
+export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
+
+export interface IDeprecatedUnionVisitor<T> {
+    'good': (obj: string) => T;
+    'noGood': (obj: string) => T;
+    'noGoodDoc': (obj: string) => T;
+    'unknown': (obj: IDeprecatedUnion) => T;
+}
+
+function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
+    if (isGood(obj)) {
+        return visitor.good(obj.good);
+    }
+    if (isNoGood(obj)) {
+        return visitor.noGood(obj.noGood);
+    }
+    if (isNoGoodDoc(obj)) {
+        return visitor.noGoodDoc(obj.noGoodDoc);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IDeprecatedUnion = {
+    isGood: isGood,
+    good: good,
+    isNoGood: isNoGood,
+    noGood: noGood,
+    isNoGoodDoc: isNoGoodDoc,
+    noGoodDoc: noGoodDoc,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
@@ -1,14 +1,14 @@
 export interface IDeprecatedUnion_Good {
-    'good': string;
-    'type': "good";
+    readonly 'good': string;
+    readonly 'type': "good";
 }
 
 /**
  * @deprecated use good
  */
 export interface IDeprecatedUnion_NoGood {
-    'noGood': string;
-    'type': "noGood";
+    readonly 'noGood': string;
+    readonly 'type': "noGood";
 }
 
 /**
@@ -16,8 +16,8 @@ export interface IDeprecatedUnion_NoGood {
  * @deprecated use good
  */
 export interface IDeprecatedUnion_NoGoodDoc {
-    'noGoodDoc': string;
-    'type': "noGoodDoc";
+    readonly 'noGoodDoc': string;
+    readonly 'type': "noGoodDoc";
 }
 
 function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
@@ -62,10 +62,10 @@ function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
 export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
 
 export interface IDeprecatedUnionVisitor<T> {
-    'good': (obj: string) => T;
-    'noGood': (obj: string) => T;
-    'noGoodDoc': (obj: string) => T;
-    'unknown': (obj: IDeprecatedUnion) => T;
+    readonly 'good': (obj: string) => T;
+    readonly 'noGood': (obj: string) => T;
+    readonly 'noGoodDoc': (obj: string) => T;
+    readonly 'unknown': (obj: IDeprecatedUnion) => T;
 }
 
 function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleAliasExample.ts
@@ -1,0 +1,4 @@
+export type IDoubleAliasExample = number | "NaN" & {
+    __conjure_type?: "DoubleAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
@@ -1,3 +1,3 @@
 export interface IDoubleExample {
-    'doubleValue': number | "NaN";
+    readonly 'doubleValue': number | "NaN";
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
@@ -1,0 +1,3 @@
+export interface IDoubleExample {
+    'doubleValue': number | "NaN";
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyEnum.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyEnum.ts
@@ -1,0 +1,3 @@
+export const EmptyEnum = {};
+
+export type EmptyEnum = void;

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyObjectExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyObjectExample.ts
@@ -1,0 +1,2 @@
+export interface IEmptyObjectExample {
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumExample.ts
@@ -1,0 +1,18 @@
+/**
+ * This enumerates the numbers 1:2 also 100.
+ * 
+ */
+export namespace EnumExample {
+    export type ONE = "ONE";
+    export type TWO = "TWO";
+    /**
+     * Value of 100.
+     */
+    export type ONE_HUNDRED = "ONE_HUNDRED";
+
+    export const ONE = "ONE" as "ONE";
+    export const TWO = "TWO" as "TWO";
+    export const ONE_HUNDRED = "ONE_HUNDRED" as "ONE_HUNDRED";
+}
+
+export type EnumExample = keyof typeof EnumExample;

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
@@ -1,5 +1,5 @@
 import { EnumExample } from "./enumExample";
 
 export interface IEnumFieldExample {
-    'enum': EnumExample;
+    readonly 'enum': EnumExample;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
@@ -1,0 +1,5 @@
+import { EnumExample } from "./enumExample";
+
+export interface IEnumFieldExample {
+    'enum': EnumExample;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
@@ -1,5 +1,5 @@
 export interface IExternalLongExample {
-    'externalLong': number;
-    'optionalExternalLong'?: number | null;
-    'listExternalLong': ReadonlyArray<number>;
+    readonly 'externalLong': number;
+    readonly 'optionalExternalLong'?: number | null;
+    readonly 'listExternalLong': ReadonlyArray<number>;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
@@ -1,0 +1,5 @@
+export interface IExternalLongExample {
+    'externalLong': number;
+    'optionalExternalLong'?: number | null;
+    'listExternalLong': ReadonlyArray<number>;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IIntegerAliasExample = number & {
+    __conjure_type?: "IntegerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
@@ -1,0 +1,3 @@
+export interface IIntegerExample {
+    'integer': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
@@ -1,3 +1,3 @@
 export interface IIntegerExample {
-    'integer': number;
+    readonly 'integer': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
@@ -1,0 +1,5 @@
+export interface IListExample {
+    'items': ReadonlyArray<string>;
+    'primitiveItems': ReadonlyArray<number>;
+    'doubleItems': ReadonlyArray<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
@@ -1,5 +1,5 @@
 export interface IListExample {
-    'items': ReadonlyArray<string>;
-    'primitiveItems': ReadonlyArray<number>;
-    'doubleItems': ReadonlyArray<number | "NaN">;
+    readonly 'items': ReadonlyArray<string>;
+    readonly 'primitiveItems': ReadonlyArray<number>;
+    readonly 'doubleItems': ReadonlyArray<number | "NaN">;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
@@ -1,0 +1,34 @@
+export interface IManyFieldExample {
+    /**
+     * docs for string field
+     */
+    'string': string;
+    /**
+     * docs for integer field
+     */
+    'integer': number;
+    /**
+     * docs for doubleValue field
+     */
+    'doubleValue': number | "NaN";
+    /**
+     * docs for optionalItem field
+     */
+    'optionalItem'?: string | null;
+    /**
+     * docs for items field
+     */
+    'items': ReadonlyArray<string>;
+    /**
+     * docs for set field
+     */
+    'set': ReadonlyArray<string>;
+    /**
+     * docs for map field
+     */
+    'map': { readonly [key: string]: string };
+    /**
+     * docs for alias field
+     */
+    'alias': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
@@ -2,33 +2,33 @@ export interface IManyFieldExample {
     /**
      * docs for string field
      */
-    'string': string;
+    readonly 'string': string;
     /**
      * docs for integer field
      */
-    'integer': number;
+    readonly 'integer': number;
     /**
      * docs for doubleValue field
      */
-    'doubleValue': number | "NaN";
+    readonly 'doubleValue': number | "NaN";
     /**
      * docs for optionalItem field
      */
-    'optionalItem'?: string | null;
+    readonly 'optionalItem'?: string | null;
     /**
      * docs for items field
      */
-    'items': ReadonlyArray<string>;
+    readonly 'items': ReadonlyArray<string>;
     /**
      * docs for set field
      */
-    'set': ReadonlyArray<string>;
+    readonly 'set': ReadonlyArray<string>;
     /**
      * docs for map field
      */
-    'map': { readonly [key: string]: string };
+    readonly 'map': { readonly [key: string]: string };
     /**
      * docs for alias field
      */
-    'alias': string;
+    readonly 'alias': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
@@ -1,0 +1,3 @@
+export interface IMapExample {
+    'items': { readonly [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
@@ -1,3 +1,3 @@
 export interface IMapExample {
-    'items': { readonly [key: string]: string };
+    readonly 'items': { readonly [key: string]: string };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
@@ -1,3 +1,3 @@
 export interface IOptionalExample {
-    'item'?: string | null;
+    readonly 'item'?: string | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
@@ -1,9 +1,9 @@
 export interface IPrimitiveOptionalsExample {
-    'num'?: number | "NaN" | null;
-    'bool'?: boolean | null;
-    'integer'?: number | null;
-    'safelong'?: number | null;
-    'rid'?: string | null;
-    'bearertoken'?: string | null;
-    'uuid'?: string | null;
+    readonly 'num'?: number | "NaN" | null;
+    readonly 'bool'?: boolean | null;
+    readonly 'integer'?: number | null;
+    readonly 'safelong'?: number | null;
+    readonly 'rid'?: string | null;
+    readonly 'bearertoken'?: string | null;
+    readonly 'uuid'?: string | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
@@ -1,0 +1,9 @@
+export interface IPrimitiveOptionalsExample {
+    'num'?: number | "NaN" | null;
+    'bool'?: boolean | null;
+    'integer'?: number | null;
+    'safelong'?: number | null;
+    'rid'?: string | null;
+    'bearertoken'?: string | null;
+    'uuid'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
@@ -1,7 +1,7 @@
 export interface IReservedKeyExample {
-    'package': string;
-    'interface': string;
-    'field-name-with-dashes': string;
-    'primitve-field-name-with-dashes': number;
-    'memoizedHashCode': number;
+    readonly 'package': string;
+    readonly 'interface': string;
+    readonly 'field-name-with-dashes': string;
+    readonly 'primitve-field-name-with-dashes': number;
+    readonly 'memoizedHashCode': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
@@ -1,0 +1,7 @@
+export interface IReservedKeyExample {
+    'package': string;
+    'interface': string;
+    'field-name-with-dashes': string;
+    'primitve-field-name-with-dashes': number;
+    'memoizedHashCode': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridAliasExample.ts
@@ -1,0 +1,4 @@
+export type IRidAliasExample = string & {
+    __conjure_type?: "RidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
@@ -1,3 +1,3 @@
 export interface IRidExample {
-    'ridValue': string;
+    readonly 'ridValue': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
@@ -1,0 +1,3 @@
+export interface IRidExample {
+    'ridValue': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongAliasExample.ts
@@ -1,0 +1,4 @@
+export type ISafeLongAliasExample = number & {
+    __conjure_type?: "SafeLongAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
@@ -1,0 +1,3 @@
+export interface ISafeLongExample {
+    'safeLongValue': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
@@ -1,3 +1,3 @@
 export interface ISafeLongExample {
-    'safeLongValue': number;
+    readonly 'safeLongValue': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
@@ -1,0 +1,4 @@
+export interface ISetExample {
+    'items': ReadonlyArray<string>;
+    'doubleItems': ReadonlyArray<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
@@ -1,4 +1,4 @@
 export interface ISetExample {
-    'items': ReadonlyArray<string>;
-    'doubleItems': ReadonlyArray<number | "NaN">;
+    readonly 'items': ReadonlyArray<string>;
+    readonly 'doubleItems': ReadonlyArray<number | "NaN">;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/simpleEnum.ts
@@ -1,0 +1,7 @@
+export namespace SimpleEnum {
+    export type VALUE = "VALUE";
+
+    export const VALUE = "VALUE" as "VALUE";
+}
+
+export type SimpleEnum = keyof typeof SimpleEnum;

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
@@ -1,6 +1,6 @@
 export interface ISingleUnion_Foo {
-    'foo': string;
-    'type': "foo";
+    readonly 'foo': string;
+    readonly 'type': "foo";
 }
 
 function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
@@ -17,8 +17,8 @@ function foo(obj: string): ISingleUnion_Foo {
 export type ISingleUnion = ISingleUnion_Foo;
 
 export interface ISingleUnionVisitor<T> {
-    'foo': (obj: string) => T;
-    'unknown': (obj: ISingleUnion) => T;
+    readonly 'foo': (obj: string) => T;
+    readonly 'unknown': (obj: ISingleUnion) => T;
 }
 
 function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
@@ -1,0 +1,35 @@
+export interface ISingleUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): ISingleUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+export type ISingleUnion = ISingleUnion_Foo;
+
+export interface ISingleUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'unknown': (obj: ISingleUnion) => T;
+}
+
+function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    return visitor.unknown(obj);
+}
+
+export const ISingleUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringAliasExample.ts
@@ -1,0 +1,4 @@
+export type IStringAliasExample = string & {
+    __conjure_type?: "StringAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringAliasOne.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringAliasOne.ts
@@ -1,0 +1,4 @@
+export type IStringAliasOne = string & {
+    __conjure_type?: "StringAliasOne",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
@@ -1,0 +1,3 @@
+export interface IStringExample {
+    'string': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
@@ -1,3 +1,3 @@
 export interface IStringExample {
-    'string': string;
+    readonly 'string': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
@@ -1,16 +1,16 @@
 export interface IUnion_Foo {
-    'foo': string;
-    'type': "foo";
+    readonly 'foo': string;
+    readonly 'type': "foo";
 }
 
 export interface IUnion_Bar {
-    'bar': number;
-    'type': "bar";
+    readonly 'bar': number;
+    readonly 'type': "bar";
 }
 
 export interface IUnion_Baz {
-    'baz': number;
-    'type': "baz";
+    readonly 'baz': number;
+    readonly 'type': "baz";
 }
 
 function isFoo(obj: IUnion): obj is IUnion_Foo {
@@ -49,10 +49,10 @@ function baz(obj: number): IUnion_Baz {
 export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
 
 export interface IUnionVisitor<T> {
-    'foo': (obj: string) => T;
-    'bar': (obj: number) => T;
-    'baz': (obj: number) => T;
-    'unknown': (obj: IUnion) => T;
+    readonly 'foo': (obj: string) => T;
+    readonly 'bar': (obj: number) => T;
+    readonly 'baz': (obj: number) => T;
+    readonly 'unknown': (obj: IUnion) => T;
 }
 
 function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
@@ -1,0 +1,79 @@
+export interface IUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+export interface IUnion_Bar {
+    'bar': number;
+    'type': "bar";
+}
+
+export interface IUnion_Baz {
+    'baz': number;
+    'type': "baz";
+}
+
+function isFoo(obj: IUnion): obj is IUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): IUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+function isBar(obj: IUnion): obj is IUnion_Bar {
+    return (obj.type === "bar");
+}
+
+function bar(obj: number): IUnion_Bar {
+    return {
+        bar: obj,
+        type: "bar",
+    };
+}
+
+function isBaz(obj: IUnion): obj is IUnion_Baz {
+    return (obj.type === "baz");
+}
+
+function baz(obj: number): IUnion_Baz {
+    return {
+        baz: obj,
+        type: "baz",
+    };
+}
+
+export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
+
+export interface IUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'bar': (obj: number) => T;
+    'baz': (obj: number) => T;
+    'unknown': (obj: IUnion) => T;
+}
+
+function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    if (isBar(obj)) {
+        return visitor.bar(obj.bar);
+    }
+    if (isBaz(obj)) {
+        return visitor.baz(obj.baz);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    isBar: isBar,
+    bar: bar,
+    isBaz: isBaz,
+    baz: baz,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
@@ -4,38 +4,38 @@ import { IStringExample } from "./stringExample";
  * Docs for when UnionTypeExample is of type StringExample.
  */
 export interface IUnionTypeExample_StringExample {
-    'stringExample': IStringExample;
-    'type': "stringExample";
+    readonly 'stringExample': IStringExample;
+    readonly 'type': "stringExample";
 }
 
 export interface IUnionTypeExample_Set {
-    'set': ReadonlyArray<string>;
-    'type': "set";
+    readonly 'set': ReadonlyArray<string>;
+    readonly 'type': "set";
 }
 
 export interface IUnionTypeExample_ThisFieldIsAnInteger {
-    'thisFieldIsAnInteger': number;
-    'type': "thisFieldIsAnInteger";
+    readonly 'thisFieldIsAnInteger': number;
+    readonly 'type': "thisFieldIsAnInteger";
 }
 
 export interface IUnionTypeExample_AlsoAnInteger {
-    'alsoAnInteger': number;
-    'type': "alsoAnInteger";
+    readonly 'alsoAnInteger': number;
+    readonly 'type': "alsoAnInteger";
 }
 
 export interface IUnionTypeExample_If {
-    'if': number;
-    'type': "if";
+    readonly 'if': number;
+    readonly 'type': "if";
 }
 
 export interface IUnionTypeExample_New {
-    'new': number;
-    'type': "new";
+    readonly 'new': number;
+    readonly 'type': "new";
 }
 
 export interface IUnionTypeExample_Interface {
-    'interface': number;
-    'type': "interface";
+    readonly 'interface': number;
+    readonly 'type': "interface";
 }
 
 function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
@@ -121,14 +121,14 @@ function interface_(obj: number): IUnionTypeExample_Interface {
 export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
 
 export interface IUnionTypeExampleVisitor<T> {
-    'stringExample': (obj: IStringExample) => T;
-    'set': (obj: ReadonlyArray<string>) => T;
-    'thisFieldIsAnInteger': (obj: number) => T;
-    'alsoAnInteger': (obj: number) => T;
-    'if': (obj: number) => T;
-    'new': (obj: number) => T;
-    'interface': (obj: number) => T;
-    'unknown': (obj: IUnionTypeExample) => T;
+    readonly 'stringExample': (obj: IStringExample) => T;
+    readonly 'set': (obj: ReadonlyArray<string>) => T;
+    readonly 'thisFieldIsAnInteger': (obj: number) => T;
+    readonly 'alsoAnInteger': (obj: number) => T;
+    readonly 'if': (obj: number) => T;
+    readonly 'new': (obj: number) => T;
+    readonly 'interface': (obj: number) => T;
+    readonly 'unknown': (obj: IUnionTypeExample) => T;
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
@@ -1,0 +1,175 @@
+import { IStringExample } from "./stringExample";
+
+/**
+ * Docs for when UnionTypeExample is of type StringExample.
+ */
+export interface IUnionTypeExample_StringExample {
+    'stringExample': IStringExample;
+    'type': "stringExample";
+}
+
+export interface IUnionTypeExample_Set {
+    'set': ReadonlyArray<string>;
+    'type': "set";
+}
+
+export interface IUnionTypeExample_ThisFieldIsAnInteger {
+    'thisFieldIsAnInteger': number;
+    'type': "thisFieldIsAnInteger";
+}
+
+export interface IUnionTypeExample_AlsoAnInteger {
+    'alsoAnInteger': number;
+    'type': "alsoAnInteger";
+}
+
+export interface IUnionTypeExample_If {
+    'if': number;
+    'type': "if";
+}
+
+export interface IUnionTypeExample_New {
+    'new': number;
+    'type': "new";
+}
+
+export interface IUnionTypeExample_Interface {
+    'interface': number;
+    'type': "interface";
+}
+
+function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
+    return (obj.type === "stringExample");
+}
+
+function stringExample(obj: IStringExample): IUnionTypeExample_StringExample {
+    return {
+        stringExample: obj,
+        type: "stringExample",
+    };
+}
+
+function isSet(obj: IUnionTypeExample): obj is IUnionTypeExample_Set {
+    return (obj.type === "set");
+}
+
+function set(obj: ReadonlyArray<string>): IUnionTypeExample_Set {
+    return {
+        set: obj,
+        type: "set",
+    };
+}
+
+function isThisFieldIsAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_ThisFieldIsAnInteger {
+    return (obj.type === "thisFieldIsAnInteger");
+}
+
+function thisFieldIsAnInteger(obj: number): IUnionTypeExample_ThisFieldIsAnInteger {
+    return {
+        thisFieldIsAnInteger: obj,
+        type: "thisFieldIsAnInteger",
+    };
+}
+
+function isAlsoAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_AlsoAnInteger {
+    return (obj.type === "alsoAnInteger");
+}
+
+function alsoAnInteger(obj: number): IUnionTypeExample_AlsoAnInteger {
+    return {
+        alsoAnInteger: obj,
+        type: "alsoAnInteger",
+    };
+}
+
+function isIf(obj: IUnionTypeExample): obj is IUnionTypeExample_If {
+    return (obj.type === "if");
+}
+
+function if_(obj: number): IUnionTypeExample_If {
+    return {
+        if: obj,
+        type: "if",
+    };
+}
+
+function isNew(obj: IUnionTypeExample): obj is IUnionTypeExample_New {
+    return (obj.type === "new");
+}
+
+function new_(obj: number): IUnionTypeExample_New {
+    return {
+        new: obj,
+        type: "new",
+    };
+}
+
+function isInterface(obj: IUnionTypeExample): obj is IUnionTypeExample_Interface {
+    return (obj.type === "interface");
+}
+
+function interface_(obj: number): IUnionTypeExample_Interface {
+    return {
+        interface: obj,
+        type: "interface",
+    };
+}
+
+/**
+ * A type which can either be a StringExample, a set of strings, or an integer.
+ */
+export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
+
+export interface IUnionTypeExampleVisitor<T> {
+    'stringExample': (obj: IStringExample) => T;
+    'set': (obj: ReadonlyArray<string>) => T;
+    'thisFieldIsAnInteger': (obj: number) => T;
+    'alsoAnInteger': (obj: number) => T;
+    'if': (obj: number) => T;
+    'new': (obj: number) => T;
+    'interface': (obj: number) => T;
+    'unknown': (obj: IUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
+    if (isStringExample(obj)) {
+        return visitor.stringExample(obj.stringExample);
+    }
+    if (isSet(obj)) {
+        return visitor.set(obj.set);
+    }
+    if (isThisFieldIsAnInteger(obj)) {
+        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+    }
+    if (isAlsoAnInteger(obj)) {
+        return visitor.alsoAnInteger(obj.alsoAnInteger);
+    }
+    if (isIf(obj)) {
+        return visitor.if(obj.if);
+    }
+    if (isNew(obj)) {
+        return visitor.new(obj.new);
+    }
+    if (isInterface(obj)) {
+        return visitor.interface(obj.interface);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnionTypeExample = {
+    isStringExample: isStringExample,
+    stringExample: stringExample,
+    isSet: isSet,
+    set: set,
+    isThisFieldIsAnInteger: isThisFieldIsAnInteger,
+    thisFieldIsAnInteger: thisFieldIsAnInteger,
+    isAlsoAnInteger: isAlsoAnInteger,
+    alsoAnInteger: alsoAnInteger,
+    isIf: isIf,
+    if_: if_,
+    isNew: isNew,
+    new_: new_,
+    isInterface: isInterface,
+    interface_: interface_,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidAliasExample.ts
@@ -1,0 +1,4 @@
+export type IUuidAliasExample = string & {
+    __conjure_type?: "UuidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
@@ -1,0 +1,3 @@
+export interface IUuidExample {
+    'uuid': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
@@ -1,3 +1,3 @@
 export interface IUuidExample {
-    'uuid': string;
+    readonly 'uuid': string;
 }

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/aliasAsMapKeyExample.ts
@@ -1,17 +1,11 @@
-import { IBearerTokenAliasExample } from "./bearerTokenAliasExample";
-import { IIntegerAliasExample } from "./integerAliasExample";
 import { IManyFieldExample } from "./manyFieldExample";
-import { IRidAliasExample } from "./ridAliasExample";
-import { ISafeLongAliasExample } from "./safeLongAliasExample";
-import { IStringAliasExample } from "./stringAliasExample";
-import { IUuidAliasExample } from "./uuidAliasExample";
 
 export interface IAliasAsMapKeyExample {
-    'strings': { [key: IStringAliasExample]: IManyFieldExample };
-    'rids': { [key: IRidAliasExample]: IManyFieldExample };
-    'bearertokens': { [key: IBearerTokenAliasExample]: IManyFieldExample };
-    'integers': { [key: IIntegerAliasExample]: IManyFieldExample };
-    'safelongs': { [key: ISafeLongAliasExample]: IManyFieldExample };
+    'strings': { [key: string]: IManyFieldExample };
+    'rids': { [key: string]: IManyFieldExample };
+    'bearertokens': { [key: string]: IManyFieldExample };
+    'integers': { [key: string]: IManyFieldExample };
+    'safelongs': { [key: string]: IManyFieldExample };
     'datetimes': { [key: string]: IManyFieldExample };
-    'uuids': { [key: IUuidAliasExample]: IManyFieldExample };
+    'uuids': { [key: string]: IManyFieldExample };
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -21,8 +21,8 @@ import * as path from "path";
 import { directory } from "tempy";
 import { generateService } from "../serviceGenerator";
 import { SimpleAst } from "../simpleAst";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { createHashableTypeName } from "../utils";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import {
     assertOutputAndExpectedAreEqual,
     foreignObject,
@@ -30,8 +30,6 @@ import {
 } from "./testTypesGeneratorTest";
 
 const stringType: IType = IType.primitive(PrimitiveType.STRING);
-
-const TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: true };
 
 describe("serviceGenerator", () => {
     const expectedDir = path.join(__dirname, "./resources");
@@ -61,7 +59,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/primitiveService.ts");
     });
@@ -91,7 +89,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/serviceWithSafelongHeader.ts");
     });
@@ -113,7 +111,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -140,7 +138,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -174,7 +172,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -217,7 +215,7 @@ describe("serviceGenerator", () => {
                 [createHashableTypeName(foreignObject.typeName), foreignObject.definition],
             ]),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -281,7 +279,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/paramTypeService.ts");
     });
@@ -324,7 +322,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/outOfOrderPathService.ts");
     });
@@ -358,7 +356,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -404,7 +402,7 @@ describe("serviceGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                TYPE_GENERATION_FLAGS,
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
         } catch (e) {
             expect(e).toEqual(new Error("endpoint cannot have more than one body arg, found: 2"));
@@ -438,7 +436,7 @@ describe("serviceGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                TYPE_GENERATION_FLAGS,
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
         } catch (e) {
             expect(e).toEqual(new Error("header arguments must define a 'param-id': foo"));
@@ -472,7 +470,7 @@ describe("serviceGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                TYPE_GENERATION_FLAGS,
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
         } catch (e) {
             expect(e).toEqual(new Error("query arguments must define a 'param-id': foo"));
@@ -498,7 +496,7 @@ describe("serviceGenerator", () => {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -541,7 +539,7 @@ export interface IMyService {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -575,7 +573,7 @@ export interface IMyService {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -628,7 +626,7 @@ export interface IMyService {
             },
             new Map(),
             simpleAst,
-            TYPE_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/optionalService.ts");
     });

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -22,12 +22,8 @@ import { directory } from "tempy";
 import { generateError } from "../errorGenerator";
 import { generateService } from "../serviceGenerator";
 import { SimpleAst } from "../simpleAst";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { generateEnum } from "../typeGenerator";
-
-const GENERATION_FLAGS_TO_USE: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("simpleAst", () => {
     let outDir: string;
@@ -49,7 +45,7 @@ describe("simpleAst", () => {
             },
             new Map(),
             simpleAst,
-            GENERATION_FLAGS_TO_USE,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
 
         await generateService(
@@ -75,7 +71,7 @@ describe("simpleAst", () => {
             },
             new Map(),
             simpleAst,
-            GENERATION_FLAGS_TO_USE,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
 
         await generateEnum(

--- a/src/commands/generate/__tests__/testTypesGeneratorTest.ts
+++ b/src/commands/generate/__tests__/testTypesGeneratorTest.ts
@@ -24,14 +24,21 @@ import { generateType } from "../typeGenerator";
 import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 export function assertOutputAndExpectedAreEqual(outDir: string, expectedDir: string, fname: string) {
-    const actual = fs.readFileSync(path.join(outDir, fname), "utf8");
-    const actualFilePath = path.join(expectedDir, fname);
+    const actualFilePath = path.join(outDir, fname);
+    const actual = fs.readFileSync(actualFilePath, "utf8");
+    const expectedFilePath = path.join(expectedDir, fname);
     if (process.env.RECREATE === "true") {
-        fs.mkdirpSync(path.dirname(actualFilePath));
-        fs.writeFileSync(actualFilePath, actual);
+        fs.mkdirpSync(path.dirname(expectedFilePath));
+        fs.writeFileSync(expectedFilePath, actual);
     } else {
-        const expected = fs.readFileSync(actualFilePath, "utf8");
-        expect(actual).toEqual(expected);
+        const expected = fs.readFileSync(expectedFilePath, "utf8");
+        try {
+            expect(actual).toEqual(expected);
+        } catch (error) {
+            // Ideally this would be a part of the expect fail message but that requires custom matchers.
+            console.error(`Expected '${actualFilePath}' contents to match '${expectedFilePath}'`);
+            throw error;
+        }
     }
 }
 

--- a/src/commands/generate/__tests__/testTypesGeneratorTest.ts
+++ b/src/commands/generate/__tests__/testTypesGeneratorTest.ts
@@ -20,8 +20,8 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import { directory } from "tempy";
 import { SimpleAst } from "../simpleAst";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { generateType } from "../typeGenerator";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 export function assertOutputAndExpectedAreEqual(outDir: string, expectedDir: string, fname: string) {
     const actual = fs.readFileSync(path.join(outDir, fname), "utf8");
@@ -60,10 +60,6 @@ export const servicesLocalObject = createSimpleObject("SomeObject", "com.palanti
 export const importsLocalObject = createSimpleObject("SomeObject", "com.palantir.imports");
 export const foreignObject = createSimpleObject("OtherObject", "com.palantir.other");
 
-const DEFAULT_GENERATION_FLAGS: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
-
 describe("testTypesGenerator", () => {
     const expectedDir = path.join(__dirname, "./resources");
     let outDir: string;
@@ -90,22 +86,22 @@ describe("testTypesGenerator", () => {
             }),
             new Map(),
             simpleAst,
-            DEFAULT_GENERATION_FLAGS,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/manyFieldExample.ts");
     });
 
     it("generates types local object", async () => {
-        await generateType(typesLocalObject.definition, new Map(), simpleAst, DEFAULT_GENERATION_FLAGS);
+        await generateType(typesLocalObject.definition, new Map(), simpleAst, DEFAULT_TYPE_GENERATION_FLAGS);
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/someObject.ts");
     });
 
     it("generates services local object", async () => {
-        await generateType(servicesLocalObject.definition, new Map(), simpleAst, DEFAULT_GENERATION_FLAGS);
+        await generateType(servicesLocalObject.definition, new Map(), simpleAst, DEFAULT_TYPE_GENERATION_FLAGS);
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "services/someObject.ts");
     });
     it("generates foreign object", async () => {
-        await generateType(foreignObject.definition, new Map(), simpleAst, DEFAULT_GENERATION_FLAGS);
+        await generateType(foreignObject.definition, new Map(), simpleAst, DEFAULT_TYPE_GENERATION_FLAGS);
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "other/otherObject.ts");
     });
 });

--- a/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
+++ b/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
@@ -18,7 +18,7 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsArgumentTypeVisitor } from "../tsArgumentTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
     const aliasName = { name: "Alias", package: "" };
@@ -179,7 +179,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             false,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         const topLevelVisitor = new TsArgumentTypeVisitor(
@@ -189,7 +189,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             true,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         it("returns list type", () => {

--- a/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
+++ b/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
@@ -17,12 +17,8 @@
 
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsArgumentTypeVisitor } from "../tsArgumentTypeVisitor";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { createHashableTypeName } from "../utils";
-
-const TYPE_GENERATION_FLAGS: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
     const binaryAliasName = { name: "BinaryAlias", package: "" };
@@ -38,14 +34,14 @@ describe("TsTypeVisitor", () => {
         new Map<string, ITypeDefinition>([[createHashableTypeName(binaryAliasName), binaryAlias]]),
         fakeTypeName,
         false,
-        TYPE_GENERATION_FLAGS,
+        DEFAULT_TYPE_GENERATION_FLAGS,
     );
 
     const topLevelVisitor = new TsArgumentTypeVisitor(
         new Map<string, ITypeDefinition>([[createHashableTypeName(binaryAliasName), binaryAlias]]),
         fakeTypeName,
         true,
-        TYPE_GENERATION_FLAGS,
+        DEFAULT_TYPE_GENERATION_FLAGS,
     );
 
     it("returns primitive types", () => {

--- a/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
+++ b/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
@@ -18,9 +18,16 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsArgumentTypeVisitor } from "../tsArgumentTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
+    const aliasName = { name: "Alias", package: "" };
+    const aliasReference = IType.reference(aliasName);
+    const alias = ITypeDefinition.alias({
+        alias: { primitive: PrimitiveType.STRING, type: "primitive" },
+        typeName: aliasName,
+    });
+
     const binaryAliasName = { name: "BinaryAlias", package: "" };
     const binaryAliasReference = IType.reference(binaryAliasName);
     const binaryAlias = ITypeDefinition.alias({
@@ -30,59 +37,173 @@ describe("TsTypeVisitor", () => {
 
     const fakeTypeName = { name: "someObject", package: "com.palantir.example" };
 
-    const visitor = new TsArgumentTypeVisitor(
-        new Map<string, ITypeDefinition>([[createHashableTypeName(binaryAliasName), binaryAlias]]),
-        fakeTypeName,
-        false,
-        DEFAULT_TYPE_GENERATION_FLAGS,
-    );
-
-    const topLevelVisitor = new TsArgumentTypeVisitor(
-        new Map<string, ITypeDefinition>([[createHashableTypeName(binaryAliasName), binaryAlias]]),
-        fakeTypeName,
-        true,
-        DEFAULT_TYPE_GENERATION_FLAGS,
-    );
-
-    it("returns primitive types", () => {
-        expect(visitor.primitive(PrimitiveType.STRING)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
-        expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
-        expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
-        expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.UUID)).toEqual("string");
-    });
-
-    it("has correct top level types", () => {
-        expect(topLevelVisitor.primitive(PrimitiveType.STRING)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
-        expect(topLevelVisitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
-        expect(topLevelVisitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(topLevelVisitor.primitive(PrimitiveType.BINARY)).toEqual(
-            "ReadableStream<Uint8Array> | BufferSource | Blob",
+    describe("with default generation flags", () => {
+        const visitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            false,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
-        expect(topLevelVisitor.primitive(PrimitiveType.ANY)).toEqual("any");
-        expect(topLevelVisitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
-        expect(topLevelVisitor.primitive(PrimitiveType.RID)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.UUID)).toEqual("string");
-    });
 
-    it("follows alias reference", () => {
-        expect(visitor.reference(binaryAliasName)).toEqual("string");
-        expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array> | BufferSource | Blob");
-    });
-
-    it("returns optional type", () => {
-        expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("string | null");
-        expect(topLevelVisitor.optional({ itemType: binaryAliasReference })).toEqual(
-            "ReadableStream<Uint8Array> | BufferSource | Blob | null",
+        const topLevelVisitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            true,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
+
+        it("returns primitive types", () => {
+            expect(visitor.primitive(PrimitiveType.STRING)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
+            expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
+            expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
+            expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
+            expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
+            expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.UUID)).toEqual("string");
+        });
+
+        it("has correct top level types", () => {
+            expect(topLevelVisitor.primitive(PrimitiveType.STRING)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
+            expect(topLevelVisitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
+            expect(topLevelVisitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
+            expect(topLevelVisitor.primitive(PrimitiveType.BINARY)).toEqual(
+                "ReadableStream<Uint8Array> | BufferSource | Blob",
+            );
+            expect(topLevelVisitor.primitive(PrimitiveType.ANY)).toEqual("any");
+            expect(topLevelVisitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
+            expect(topLevelVisitor.primitive(PrimitiveType.RID)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.UUID)).toEqual("string");
+        });
+
+        it("follows alias reference", () => {
+            expect(visitor.reference(aliasName)).toEqual("string");
+            expect(visitor.reference(binaryAliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(aliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array> | BufferSource | Blob");
+        });
+
+        it("returns optional type", () => {
+            expect(visitor.optional({ itemType: aliasReference })).toEqual("string | null");
+            expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("string | null");
+            expect(topLevelVisitor.optional({ itemType: aliasReference })).toEqual("string | null");
+            expect(topLevelVisitor.optional({ itemType: binaryAliasReference })).toEqual(
+                "ReadableStream<Uint8Array> | BufferSource | Blob | null",
+            );
+        });
+
+        it("returns list type", () => {
+            expect(visitor.list({ itemType: aliasReference })).toEqual("Array<string>");
+            expect(visitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.list({ itemType: aliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+
+        it("returns set type", () => {
+            expect(visitor.set({ itemType: aliasReference })).toEqual("Array<string>");
+            expect(visitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(visitor.set({ itemType: aliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+    });
+
+    describe("with flavored generation flags", () => {
+        const visitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            false,
+            FLAVORED_TYPE_GENERATION_FLAGS,
+        );
+
+        const topLevelVisitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            true,
+            FLAVORED_TYPE_GENERATION_FLAGS,
+        );
+
+        it("follows alias reference", () => {
+            expect(visitor.reference(aliasName)).toEqual("IAlias");
+            expect(visitor.reference(binaryAliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(aliasName)).toEqual("IAlias");
+            expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array> | BufferSource | Blob");
+        });
+
+        it("returns optional type", () => {
+            expect(visitor.optional({ itemType: aliasReference })).toEqual("IAlias | null");
+            expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("string | null");
+            expect(topLevelVisitor.optional({ itemType: aliasReference })).toEqual("IAlias | null");
+            expect(topLevelVisitor.optional({ itemType: binaryAliasReference })).toEqual(
+                "ReadableStream<Uint8Array> | BufferSource | Blob | null",
+            );
+        });
+
+        it("returns list type", () => {
+            expect(visitor.list({ itemType: aliasReference })).toEqual("Array<IAlias>");
+            expect(visitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.list({ itemType: aliasReference })).toEqual("Array<IAlias>");
+            expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+
+        it("returns set type", () => {
+            expect(visitor.set({ itemType: aliasReference })).toEqual("Array<IAlias>");
+            expect(visitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(visitor.set({ itemType: aliasReference })).toEqual("Array<IAlias>");
+            expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+    });
+
+    describe("with readonly generation flags", () => {
+        const visitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            false,
+            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+        );
+
+        const topLevelVisitor = new TsArgumentTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias]
+            ]),
+            fakeTypeName,
+            true,
+            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+        );
+
+        it("returns list type", () => {
+            expect(visitor.list({ itemType: aliasReference })).toEqual("ReadonlyArray<string>");
+            expect(visitor.list({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+            expect(topLevelVisitor.list({ itemType: aliasReference })).toEqual("ReadonlyArray<string>");
+            expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+        });
+
+        it("returns set type", () => {
+            expect(visitor.set({ itemType: aliasReference })).toEqual("ReadonlyArray<string>");
+            expect(visitor.set({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+            expect(visitor.set({ itemType: aliasReference })).toEqual("ReadonlyArray<string>");
+            expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+        });
     });
 });

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -18,7 +18,7 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsReturnTypeVisitor } from "../tsReturnTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 const objectName = { name: "Object", package: "" };
 const objectReference = IType.reference(objectName);
@@ -229,7 +229,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             false,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         const topLevelVisitor = new TsReturnTypeVisitor(
@@ -241,7 +241,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             true,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         it("returns list type", () => {

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -218,7 +218,7 @@ describe("TsTypeVisitor", () => {
         });
     });
 
-    describe("with readonlyCollections flag", () => {
+    describe("with readonlyInterfaces flag", () => {
 
         const visitor = new TsReturnTypeVisitor(
             new Map<string, ITypeDefinition>([

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -18,7 +18,7 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsReturnTypeVisitor } from "../tsReturnTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
     const objectName = { name: "Object", package: "" };
@@ -60,7 +60,7 @@ describe("TsTypeVisitor", () => {
         ]),
         fakeTypeName,
         false,
-        DEFAULT_TYPE_GENERATION_FLAGS,
+        FLAVORED_TYPE_GENERATION_FLAGS,
     );
 
     const topLevelVisitor = new TsReturnTypeVisitor(
@@ -72,7 +72,7 @@ describe("TsTypeVisitor", () => {
         ]),
         fakeTypeName,
         true,
-        DEFAULT_TYPE_GENERATION_FLAGS,
+        FLAVORED_TYPE_GENERATION_FLAGS,
     );
 
     it("returns primitive types", () => {

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -18,164 +18,268 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsReturnTypeVisitor } from "../tsReturnTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+
+const objectName = { name: "Object", package: "" };
+const objectReference = IType.reference(objectName);
+const object = ITypeDefinition.object({
+    fields: [],
+    typeName: objectName,
+});
+
+const aliasName = { name: "Alias", package: "" };
+const aliasReference = IType.reference(aliasName);
+const alias = ITypeDefinition.alias({
+    alias: { primitive: PrimitiveType.STRING, type: "primitive" },
+    typeName: aliasName,
+});
+
+const binaryAliasName = { name: "BinaryAlias", package: "" };
+const binaryAliasReference = IType.reference(binaryAliasName);
+const binaryAlias = ITypeDefinition.alias({
+    alias: { primitive: PrimitiveType.BINARY, type: "primitive" },
+    typeName: binaryAliasName,
+});
+
+const enumName = { name: "Enum", package: "" };
+const enumReference = IType.reference(enumName);
+const enumType = ITypeDefinition.enum_({
+    typeName: enumName,
+    values: [{ value: "FOO" }],
+});
+
+const fakeTypeName = { name: "someObject", package: "com.palantir.example" };
 
 describe("TsTypeVisitor", () => {
-    const objectName = { name: "Object", package: "" };
-    const objectReference = IType.reference(objectName);
-    const object = ITypeDefinition.object({
-        fields: [],
-        typeName: objectName,
-    });
 
-    const aliasName = { name: "Alias", package: "" };
-    const aliasReference = IType.reference(aliasName);
-    const alias = ITypeDefinition.alias({
-        alias: { primitive: PrimitiveType.STRING, type: "primitive" },
-        typeName: aliasName,
-    });
+    describe("with default generation flags", () => {
 
-    const binaryAliasName = { name: "BinaryAlias", package: "" };
-    const binaryAliasReference = IType.reference(binaryAliasName);
-    const binaryAlias = ITypeDefinition.alias({
-        alias: { primitive: PrimitiveType.BINARY, type: "primitive" },
-        typeName: binaryAliasName,
-    });
-
-    const enumName = { name: "Enum", package: "" };
-    const enumReference = IType.reference(enumName);
-    const enumType = ITypeDefinition.enum_({
-        typeName: enumName,
-        values: [{ value: "FOO" }],
-    });
-
-    const fakeTypeName = { name: "someObject", package: "com.palantir.example" };
-
-    const visitor = new TsReturnTypeVisitor(
-        new Map<string, ITypeDefinition>([
-            [createHashableTypeName(objectName), object],
-            [createHashableTypeName(aliasName), alias],
-            [createHashableTypeName(binaryAliasName), binaryAlias],
-            [createHashableTypeName(enumName), enumType],
-        ]),
-        fakeTypeName,
-        false,
-        FLAVORED_TYPE_GENERATION_FLAGS,
-    );
-
-    const topLevelVisitor = new TsReturnTypeVisitor(
-        new Map<string, ITypeDefinition>([
-            [createHashableTypeName(objectName), object],
-            [createHashableTypeName(aliasName), alias],
-            [createHashableTypeName(binaryAliasName), binaryAlias],
-            [createHashableTypeName(enumName), enumType],
-        ]),
-        fakeTypeName,
-        true,
-        FLAVORED_TYPE_GENERATION_FLAGS,
-    );
-
-    it("returns primitive types", () => {
-        expect(visitor.primitive(PrimitiveType.STRING)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
-        expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
-        expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
-        expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
-        expect(visitor.primitive(PrimitiveType.UUID)).toEqual("string");
-    });
-
-    it("has correct top level types", () => {
-        expect(topLevelVisitor.primitive(PrimitiveType.STRING)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
-        expect(topLevelVisitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
-        expect(topLevelVisitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
-        expect(topLevelVisitor.primitive(PrimitiveType.BINARY)).toEqual("ReadableStream<Uint8Array>");
-        expect(topLevelVisitor.primitive(PrimitiveType.ANY)).toEqual("any");
-        expect(topLevelVisitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
-        expect(topLevelVisitor.primitive(PrimitiveType.RID)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
-        expect(topLevelVisitor.primitive(PrimitiveType.UUID)).toEqual("string");
-    });
-
-    it("produces error for unknown reference", () => {
-        const tsType = () =>
-            new TsReturnTypeVisitor(new Map(), fakeTypeName, false, FLAVORED_TYPE_GENERATION_FLAGS).reference(objectName);
-        expect(tsType).toThrowError(/unknown reference type/);
-    });
-
-    it("returns reference type", () => {
-        expect(visitor.reference(objectName)).toEqual("IObject");
-    });
-
-    it("follows alias reference", () => {
-        expect(visitor.reference(aliasName)).toEqual("IAlias");
-        expect(visitor.reference(binaryAliasName)).toEqual("string");
-        expect(topLevelVisitor.reference(aliasName)).toEqual("IAlias");
-        expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array>");
-    });
-
-    it("returns enum reference without I prefix", () => {
-        expect(visitor.reference(enumName)).toEqual("Enum");
-    });
-
-    it("returns optional type", () => {
-        expect(visitor.optional({ itemType: objectReference })).toEqual("IObject | null");
-        expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("string | null");
-        expect(topLevelVisitor.optional({ itemType: binaryAliasReference })).toEqual(
-            "ReadableStream<Uint8Array> | null",
+        const visitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            false,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
-    });
 
-    it("returns list type", () => {
-        expect(visitor.list({ itemType: objectReference })).toEqual("Array<IObject>");
-        expect(visitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
-        expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
-    });
-
-    it("returns set type", () => {
-        expect(visitor.set({ itemType: objectReference })).toEqual("Array<IObject>");
-        expect(visitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
-        expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
-    });
-
-    it("returns map type", () => {
-        expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
-            "{ [key: IAlias]: IObject }",
+        const topLevelVisitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            true,
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
-        expect(visitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
-            "{ [key: IAlias]: string }",
+
+        it("returns primitive types", () => {
+            expect(visitor.primitive(PrimitiveType.STRING)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
+            expect(visitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
+            expect(visitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
+            expect(visitor.primitive(PrimitiveType.BINARY)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.ANY)).toEqual("any");
+            expect(visitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
+            expect(visitor.primitive(PrimitiveType.RID)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
+            expect(visitor.primitive(PrimitiveType.UUID)).toEqual("string");
+        });
+
+        it("has correct top level types", () => {
+            expect(topLevelVisitor.primitive(PrimitiveType.STRING)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.DATETIME)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.INTEGER)).toEqual("number");
+            expect(topLevelVisitor.primitive(PrimitiveType.DOUBLE)).toEqual('number | "NaN"');
+            expect(topLevelVisitor.primitive(PrimitiveType.SAFELONG)).toEqual("number");
+            expect(topLevelVisitor.primitive(PrimitiveType.BINARY)).toEqual("ReadableStream<Uint8Array>");
+            expect(topLevelVisitor.primitive(PrimitiveType.ANY)).toEqual("any");
+            expect(topLevelVisitor.primitive(PrimitiveType.BOOLEAN)).toEqual("boolean");
+            expect(topLevelVisitor.primitive(PrimitiveType.RID)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.BEARERTOKEN)).toEqual("string");
+            expect(topLevelVisitor.primitive(PrimitiveType.UUID)).toEqual("string");
+        });
+
+        it("produces error for unknown reference", () => {
+            const tsType = () =>
+                new TsReturnTypeVisitor(new Map(), fakeTypeName, false, FLAVORED_TYPE_GENERATION_FLAGS).reference(objectName);
+            expect(tsType).toThrowError(/unknown reference type/);
+        });
+
+        it("returns reference type", () => {
+            expect(visitor.reference(objectName)).toEqual("IObject");
+        });
+
+        it("follows alias reference", () => {
+            expect(visitor.reference(aliasName)).toEqual("string");
+            expect(visitor.reference(binaryAliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(aliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array>");
+        });
+
+        it("returns enum reference without I prefix", () => {
+            expect(visitor.reference(enumName)).toEqual("Enum");
+        });
+
+        it("returns optional type", () => {
+            expect(visitor.optional({ itemType: objectReference })).toEqual("IObject | null");
+            expect(visitor.optional({ itemType: binaryAliasReference })).toEqual("string | null");
+            expect(topLevelVisitor.optional({ itemType: binaryAliasReference })).toEqual(
+                "ReadableStream<Uint8Array> | null",
+            );
+        });
+
+        it("returns list type", () => {
+            expect(visitor.list({ itemType: objectReference })).toEqual("Array<IObject>");
+            expect(visitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+
+        it("returns set type", () => {
+            expect(visitor.set({ itemType: objectReference })).toEqual("Array<IObject>");
+            expect(visitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+            expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("Array<string>");
+        });
+
+        it("returns map type", () => {
+            expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
+                "{ [key: string]: IObject }",
+            );
+            expect(visitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
+                "{ [key: string]: string }",
+            );
+            expect(topLevelVisitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
+                "{ [key: string]: string }",
+            );
+        });
+
+        it("returns map type with enum keys", () => {
+            const tsType = visitor.map({ keyType: enumReference, valueType: objectReference });
+            expect(tsType).toEqual(`{ [key in ${enumName.name}]?: IObject }`);
+        });
+
+        it("follows primitive external fallback", () => {
+            const unusedTypeName = { name: "Unused", package: "" };
+            const externalType = {
+                externalReference: unusedTypeName,
+                fallback: IType.primitive(PrimitiveType.ANY),
+            };
+            expect(visitor.external(externalType)).toEqual("any");
+        });
+
+        it("follows complex external fallback", () => {
+            const unusedTypeName = { name: "Unused", package: "" };
+            const externalType = {
+                externalReference: unusedTypeName,
+                fallback: IType.list({ itemType: objectReference }),
+            };
+            expect(visitor.external(externalType)).toEqual("Array<IObject>");
+        });
+    });
+
+
+    describe("with flavored generation flags", () => {
+
+        const visitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            false,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
-        expect(topLevelVisitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
-            "{ [key: IAlias]: string }",
+
+        const topLevelVisitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            true,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
+
+        it("follows alias reference", () => {
+            expect(visitor.reference(aliasName)).toEqual("IAlias");
+            expect(visitor.reference(binaryAliasName)).toEqual("string");
+            expect(topLevelVisitor.reference(aliasName)).toEqual("IAlias");
+            expect(topLevelVisitor.reference(binaryAliasName)).toEqual("ReadableStream<Uint8Array>");
+        });
     });
 
-    it("returns map type with enum keys", () => {
-        const tsType = visitor.map({ keyType: enumReference, valueType: objectReference });
-        expect(tsType).toEqual(`{ [key in ${enumName.name}]?: IObject }`);
-    });
+    describe("with readonlyCollections flag", () => {
 
-    it("follows primitive external fallback", () => {
-        const unusedTypeName = { name: "Unused", package: "" };
-        const externalType = {
-            externalReference: unusedTypeName,
-            fallback: IType.primitive(PrimitiveType.ANY),
-        };
-        expect(visitor.external(externalType)).toEqual("any");
-    });
+        const visitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            false,
+            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+        );
 
-    it("follows complex external fallback", () => {
-        const unusedTypeName = { name: "Unused", package: "" };
-        const externalType = {
-            externalReference: unusedTypeName,
-            fallback: IType.list({ itemType: objectReference }),
-        };
-        expect(visitor.external(externalType)).toEqual("Array<IObject>");
+        const topLevelVisitor = new TsReturnTypeVisitor(
+            new Map<string, ITypeDefinition>([
+                [createHashableTypeName(objectName), object],
+                [createHashableTypeName(aliasName), alias],
+                [createHashableTypeName(binaryAliasName), binaryAlias],
+                [createHashableTypeName(enumName), enumType],
+            ]),
+            fakeTypeName,
+            true,
+            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+        );
+
+        it("returns list type", () => {
+            expect(visitor.list({ itemType: objectReference })).toEqual("ReadonlyArray<IObject>");
+            expect(visitor.list({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+            expect(topLevelVisitor.list({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+        });
+
+        it("returns set type", () => {
+            expect(visitor.set({ itemType: objectReference })).toEqual("ReadonlyArray<IObject>");
+            expect(visitor.set({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+            expect(topLevelVisitor.set({ itemType: binaryAliasReference })).toEqual("ReadonlyArray<string>");
+        });
+
+        it("returns map type", () => {
+            expect(visitor.map({ keyType: aliasReference, valueType: objectReference })).toEqual(
+                "{ readonly [key: string]: IObject }",
+            );
+            expect(visitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
+                "{ readonly [key: string]: string }",
+            );
+            expect(topLevelVisitor.map({ keyType: aliasReference, valueType: binaryAliasReference })).toEqual(
+                "{ readonly [key: string]: string }",
+            );
+        });
+
+        it("returns map type with enum keys", () => {
+            const tsType = visitor.map({ keyType: enumReference, valueType: objectReference });
+            expect(tsType).toEqual(`{ readonly [key in ${enumName.name}]?: IObject }`);
+        });
+
+        it("follows complex external fallback", () => {
+            const unusedTypeName = { name: "Unused", package: "" };
+            const externalType = {
+                externalReference: unusedTypeName,
+                fallback: IType.list({ itemType: objectReference }),
+            };
+            expect(visitor.external(externalType)).toEqual("ReadonlyArray<IObject>");
+        });
     });
 });

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -17,12 +17,8 @@
 
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsReturnTypeVisitor } from "../tsReturnTypeVisitor";
-import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { createHashableTypeName } from "../utils";
-
-const GENERATION_FLAGS_TO_USE: ITypeGenerationFlags = {
-    flavorizedAliases: true,
-};
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
     const objectName = { name: "Object", package: "" };
@@ -64,7 +60,7 @@ describe("TsTypeVisitor", () => {
         ]),
         fakeTypeName,
         false,
-        GENERATION_FLAGS_TO_USE,
+        DEFAULT_TYPE_GENERATION_FLAGS,
     );
 
     const topLevelVisitor = new TsReturnTypeVisitor(
@@ -76,7 +72,7 @@ describe("TsTypeVisitor", () => {
         ]),
         fakeTypeName,
         true,
-        GENERATION_FLAGS_TO_USE,
+        DEFAULT_TYPE_GENERATION_FLAGS,
     );
 
     it("returns primitive types", () => {
@@ -109,7 +105,7 @@ describe("TsTypeVisitor", () => {
 
     it("produces error for unknown reference", () => {
         const tsType = () =>
-            new TsReturnTypeVisitor(new Map(), fakeTypeName, false, GENERATION_FLAGS_TO_USE).reference(objectName);
+            new TsReturnTypeVisitor(new Map(), fakeTypeName, false, FLAVORED_TYPE_GENERATION_FLAGS).reference(objectName);
         expect(tsType).toThrowError(/unknown reference type/);
     });
 

--- a/src/commands/generate/__tests__/typeGeneratorTest.ts
+++ b/src/commands/generate/__tests__/typeGeneratorTest.ts
@@ -589,7 +589,7 @@ describe("typeGenerator", () => {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            DEFAULT_TYPE_GENERATION_FLAGS,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "types/myUnion.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -640,7 +640,7 @@ import { IStringAlias } from "./stringAlias";
                 [createHashableTypeName(dateAliasName), dateAlias],
             ]),
             simpleAst,
-            DEFAULT_TYPE_GENERATION_FLAGS,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "types/myUnion.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -720,7 +720,7 @@ export interface IMyUnion_DateAlias {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            DEFAULT_TYPE_GENERATION_FLAGS,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/recursiveUnion.ts");
     });
@@ -747,7 +747,7 @@ export interface IMyUnion_DateAlias {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            DEFAULT_TYPE_GENERATION_FLAGS,
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/recursiveObject.ts");
     });

--- a/src/commands/generate/__tests__/typeGeneratorTest.ts
+++ b/src/commands/generate/__tests__/typeGeneratorTest.ts
@@ -22,6 +22,7 @@ import { directory } from "tempy";
 import { SimpleAst } from "../simpleAst";
 import { generateAlias, generateEnum, generateObject, generateUnion } from "../typeGenerator";
 import { createHashableTypeName } from "../utils";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import {
     assertDoesNotExist,
     assertOutputAndExpectedAreEqual,
@@ -120,9 +121,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/primitiveObject.ts");
     });
@@ -140,9 +139,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/uuidObject.ts");
     });
@@ -156,9 +153,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/customEntityRid.ts");
         });
@@ -171,9 +166,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/customEntityRidWithFlagOff.ts");
         });
@@ -188,9 +181,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/stringAlias.ts");
         });
@@ -203,9 +194,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/stringAliasWhenFlagOff.ts");
         });
@@ -220,9 +209,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/integerAlias.ts");
         });
@@ -235,9 +222,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/integerAliasWithFlagOff.ts");
         });
@@ -252,9 +237,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/safeLongAlias.ts");
         });
@@ -267,9 +250,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/safeLongAliasWithFlagOff.ts");
         });
@@ -284,9 +265,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/bearerTokenAlias.ts");
         });
@@ -299,9 +278,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/bearerTokenAliasWithFlagOff.ts");
         });
@@ -316,9 +293,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: true,
-                },
+                FLAVORED_TYPE_GENERATION_FLAGS,
             );
             assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/uuidAlias.ts");
         });
@@ -331,9 +306,7 @@ describe("typeGenerator", () => {
                 },
                 new Map(),
                 simpleAst,
-                {
-                    flavorizedAliases: false,
-                },
+                DEFAULT_TYPE_GENERATION_FLAGS,
             );
             assertDoesNotExist(outDir, "types/uuidAliasWithFlagOff.ts");
         });
@@ -360,9 +333,7 @@ describe("typeGenerator", () => {
             },
             new Map([[createHashableTypeName(someEnum.typeName), ITypeDefinition.enum_(someEnum)]]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/enumMapObject.ts");
     });
@@ -387,9 +358,7 @@ describe("typeGenerator", () => {
                 [createHashableTypeName(localObject.typeName), localObject.definition],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/referenceObject.ts");
     });
@@ -414,9 +383,7 @@ describe("typeGenerator", () => {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/aliasReferenceObject.ts");
     });
@@ -442,9 +409,7 @@ describe("typeGenerator", () => {
                 [createHashableTypeName(stringAlias.alias.typeName), stringAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            FLAVORED_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/nestedAliasReferenceObject.ts");
     });
@@ -467,9 +432,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/optionalObject.ts");
     });
@@ -494,9 +457,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/objectWithDocs.ts");
     });
@@ -522,9 +483,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/primitiveUnion.ts");
     });
@@ -540,9 +499,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/unionTypeExample.ts");
     });
@@ -566,9 +523,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/unionWithDocs.ts");
     });
@@ -590,9 +545,7 @@ describe("typeGenerator", () => {
             },
             new Map(),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "types/myUnion.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -636,9 +589,7 @@ describe("typeGenerator", () => {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "types/myUnion.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -689,9 +640,7 @@ import { IStringAlias } from "./stringAlias";
                 [createHashableTypeName(dateAliasName), dateAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         const outFile = path.join(outDir, "types/myUnion.ts");
         const contents = fs.readFileSync(outFile, "utf8");
@@ -734,9 +683,7 @@ export interface IMyUnion_DateAlias {
             typeName: littleTypeName,
             union: [{ fieldName: "double", type: IType.primitive(PrimitiveType.DOUBLE) }],
         };
-        await generateUnion(littleUnion, new Map(), simpleAst, {
-            flavorizedAliases: true,
-        });
+        await generateUnion(littleUnion, new Map(), simpleAst, DEFAULT_TYPE_GENERATION_FLAGS);
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/little.ts");
 
         await generateUnion(
@@ -746,9 +693,7 @@ export interface IMyUnion_DateAlias {
             },
             new Map([[createHashableTypeName(littleTypeName), ITypeDefinition.union(littleUnion)]]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/big.ts");
     });
@@ -775,9 +720,7 @@ export interface IMyUnion_DateAlias {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/recursiveUnion.ts");
     });
@@ -804,9 +747,7 @@ export interface IMyUnion_DateAlias {
                 [createHashableTypeName(stringAliasName), stringAlias],
             ]),
             simpleAst,
-            {
-                flavorizedAliases: true,
-            },
+            DEFAULT_TYPE_GENERATION_FLAGS,
         );
         assertOutputAndExpectedAreEqual(outDir, expectedDir, "types/recursiveObject.ts");
     });

--- a/src/commands/generate/errorGenerator.ts
+++ b/src/commands/generate/errorGenerator.ts
@@ -53,18 +53,22 @@ export function generateError(
             {
                 name: singleQuote("errorCode"),
                 type: doubleQuote(definition.code),
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("errorInstanceId"),
                 type: "string",
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("errorName"),
                 type: doubleQuote(errorName),
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("parameters"),
                 type: `{\n${properties}}`,
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
         ],
     });

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -58,6 +58,11 @@ export interface IGenerateCommandArgs {
      * Generates flavoured types for compatible aliases (string, rids...)
      */
     flavorizedAliases?: boolean;
+
+    /**
+     * Generated interfaces use ReadonlyArray instead of Array and readonly map patterns
+     */
+    readonlyCollections?: boolean;
 }
 
 interface ICleanedGenerateCommandArgs {
@@ -113,6 +118,11 @@ export class GenerateCommand implements CommandModule {
                 describe: "Generate raw source without any package metadata",
                 type: "boolean",
             })
+            .option("readonlyCollections", {
+                default: false,
+                describe: "Generated interfaces use ReadonlyArray instead of Array and readonly map patterns",
+                type: "boolean",
+            })
             .option("productDependencies", {
                 default: undefined,
                 describe: "Path to a file containing a list of product dependencies",
@@ -126,7 +136,8 @@ export class GenerateCommand implements CommandModule {
         const { rawSource } = args;
         const { conjureDefinition, packageJson, tsConfig, gitIgnore } = await this.parseCommandLineArguments(args);
         const generatePromise = generate(conjureDefinition, output, {
-            flavorizedAliases: !!args.flavorizedAliases,
+            flavorizedAliases: args.flavorizedAliases ?? false,
+            readonlyCollections: args.readonlyCollections ?? false,
         });
         if (rawSource) {
             return generatePromise;

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -63,6 +63,11 @@ export interface IGenerateCommandArgs {
      * Generated interfaces use ReadonlyArray instead of Array and readonly map patterns
      */
     readonlyCollections?: boolean;
+
+    /**
+     * Generated interfaces have readonly properties
+     */
+    readonlyInterfaces?: boolean;
 }
 
 interface ICleanedGenerateCommandArgs {
@@ -123,6 +128,11 @@ export class GenerateCommand implements CommandModule {
                 describe: "Generated interfaces use ReadonlyArray instead of Array and readonly map patterns",
                 type: "boolean",
             })
+            .option("readonlyInterfaces", {
+                default: false,
+                describe: "Generated interfaces have readonly properties",
+                type: "boolean",
+            })
             .option("productDependencies", {
                 default: undefined,
                 describe: "Path to a file containing a list of product dependencies",
@@ -138,6 +148,7 @@ export class GenerateCommand implements CommandModule {
         const generatePromise = generate(conjureDefinition, output, {
             flavorizedAliases: args.flavorizedAliases ?? false,
             readonlyCollections: args.readonlyCollections ?? false,
+            readonlyInterfaces: args.readonlyInterfaces ?? false,
         });
         if (rawSource) {
             return generatePromise;

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -60,12 +60,7 @@ export interface IGenerateCommandArgs {
     flavorizedAliases?: boolean;
 
     /**
-     * Generated interfaces use ReadonlyArray instead of Array and readonly map patterns
-     */
-    readonlyCollections?: boolean;
-
-    /**
-     * Generated interfaces have readonly properties
+     * Generated interfaces have readonly properties and collections
      */
     readonlyInterfaces?: boolean;
 }
@@ -123,14 +118,9 @@ export class GenerateCommand implements CommandModule {
                 describe: "Generate raw source without any package metadata",
                 type: "boolean",
             })
-            .option("readonlyCollections", {
-                default: false,
-                describe: "Generated interfaces use ReadonlyArray instead of Array and readonly map patterns",
-                type: "boolean",
-            })
             .option("readonlyInterfaces", {
                 default: false,
-                describe: "Generated interfaces have readonly properties",
+                describe: "Generated interfaces have readonly properties and collections",
                 type: "boolean",
             })
             .option("productDependencies", {
@@ -147,7 +137,6 @@ export class GenerateCommand implements CommandModule {
         const { conjureDefinition, packageJson, tsConfig, gitIgnore } = await this.parseCommandLineArguments(args);
         const generatePromise = generate(conjureDefinition, output, {
             flavorizedAliases: args.flavorizedAliases ?? false,
-            readonlyCollections: args.readonlyCollections ?? false,
             readonlyInterfaces: args.readonlyInterfaces ?? false,
         });
         if (rawSource) {

--- a/src/commands/generate/tsReturnTypeVisitor.ts
+++ b/src/commands/generate/tsReturnTypeVisitor.ts
@@ -65,7 +65,7 @@ export class TsReturnTypeVisitor implements ITypeVisitor<string> {
     };
     public map = (obj: IMapType): string => {
         const valueTsType = IType.visit(obj.valueType, this.nestedVisitor());
-        const maybeReadonly = this.typeGenerationFlags.readonlyCollections ? 'readonly ' : '';
+        const maybeReadonly = this.typeGenerationFlags.readonlyInterfaces ? 'readonly ' : '';
         if (IType.isReference(obj.keyType)) {
             const keyTypeDefinition = this.knownTypes.get(createHashableTypeName(obj.keyType.reference));
             if (keyTypeDefinition != null) {
@@ -124,6 +124,6 @@ export class TsReturnTypeVisitor implements ITypeVisitor<string> {
         return new TsReturnTypeVisitor(this.knownTypes, this.currType, false, this.typeGenerationFlags);
     };
     protected getArrayType(itemType: string) {
-        return this.typeGenerationFlags.readonlyCollections ? `ReadonlyArray<${itemType}>` :  `Array<${itemType}>`;
+        return this.typeGenerationFlags.readonlyInterfaces ? `ReadonlyArray<${itemType}>` :  `Array<${itemType}>`;
     }
 }

--- a/src/commands/generate/typeGenerationFlags.ts
+++ b/src/commands/generate/typeGenerationFlags.ts
@@ -28,4 +28,9 @@ export interface ITypeGenerationFlags {
      * Generated interfaces use ReadonlyArray instead of Array.
      */
     readonly readonlyCollections: boolean;
+
+    /**
+     * Generated interfaces have readonly properties.
+     */
+    readonly readonlyInterfaces: boolean;
 }

--- a/src/commands/generate/typeGenerationFlags.ts
+++ b/src/commands/generate/typeGenerationFlags.ts
@@ -25,12 +25,7 @@ export interface ITypeGenerationFlags {
     readonly flavorizedAliases: boolean;
 
     /**
-     * Generated interfaces use ReadonlyArray instead of Array.
-     */
-    readonly readonlyCollections: boolean;
-
-    /**
-     * Generated interfaces have readonly properties.
+     * Generated interfaces have readonly properties and use ReadonlyArray instead of Array.
      */
     readonly readonlyInterfaces: boolean;
 }

--- a/src/commands/generate/typeGenerationFlags.ts
+++ b/src/commands/generate/typeGenerationFlags.ts
@@ -22,5 +22,10 @@ export interface ITypeGenerationFlags {
     /**
      * When set to true compatible alias types will be converted as flavoured strings.
      */
-    flavorizedAliases: boolean;
+    readonly flavorizedAliases: boolean;
+
+    /**
+     * Generated interfaces use ReadonlyArray instead of Array.
+     */
+    readonly readonlyCollections: boolean;
 }

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -197,6 +197,7 @@ export async function generateObject(
             name: singleQuote(fieldDefinition.fieldName),
             type: fieldType,
             docs: addDeprecatedToDocs(fieldDefinition),
+            isReadonly: typeGenerationFlags.readonlyInterfaces,
         };
 
         properties.push(property);
@@ -325,10 +326,12 @@ function processUnionMembers(
                 {
                     name: singleQuote(memberName),
                     type: fieldType,
+                    isReadonly: typeGenerationFlags.readonlyInterfaces,
                 },
                 {
                     name: singleQuote("type"),
                     type: doubleQuote(memberName),
+                    isReadonly: typeGenerationFlags.readonlyInterfaces,
                 },
             ],
         });
@@ -372,6 +375,7 @@ function processUnionMembers(
         visitorProperties.push({
             name: singleQuote(memberName),
             type: `(obj: ${fieldType}) => T`,
+            isReadonly: typeGenerationFlags.readonlyInterfaces,
         });
         visitorStatements.push(`if (${typeGuard.name}(${obj})) {
             return ${visitor}.${memberName}(${obj}.${memberName});
@@ -381,6 +385,7 @@ function processUnionMembers(
     visitorProperties.push({
         name: singleQuote("unknown"),
         type: `(obj: ${unionTsType}) => T`,
+        isReadonly: typeGenerationFlags.readonlyInterfaces,
     });
     visitorStatements.push(`return ${visitor}.unknown(${obj});`);
 


### PR DESCRIPTION
Fixes #155 

😞 Unfortunately it's a large commit due to the `*-test-cases` files, collapse the `resources` dir and it's not so bad... A couple of refactored tests are best viewed with whitespace diff off

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Generated typescript was difficult to work with in a project with strict readonly usage, often requiring casting from readonly arrays to mutable arrays to make service calls. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Typescript generation with the readonlyInterfaces flag emits interfaces with readonly fields, and collections are readonly also.

Includes a refactor for better testing of flavoredAliases vs default generation, so that we could also adds tests for readonlyInterfaces generation.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Like with `flavoredAliases`, the generated typescript is likely breaking for many existing consumers, so I expect this will remain a default off flag, though I'd recommend it for new APIs.

