### PR TITLE
Add readonlyInterfaces flag

### DIFF
--- a/src/commands/generate/__tests__/generatorTest.ts
+++ b/src/commands/generate/__tests__/generatorTest.ts
@@ -33,7 +33,7 @@ import { generate } from "../generator";
 import { typeNameToFilePath } from "../simpleAst";
 import { ITypeGenerationFlags } from "../typeGenerationFlags";
 import { isFlavorizable } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { assertOutputAndExpectedAreEqual } from "./testTypesGeneratorTest";
 
 describe("generator", () => {
@@ -126,7 +126,7 @@ describe("definitionTests", () => {
 
         // Not every test has a readonly version
         if (fs.existsSync(actualReadonlyTestCaseDir)) {
-            it(`${fileName} produces equivalent readonly TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualReadonlyTestCaseDir, READONLY_COLLECTION_TYPE_GENERATION_FLAGS));
+            it(`${fileName} produces equivalent readonly TypeScript`, testGenerateAllFilesAreTheSame(definitionFilePath, paths, actualReadonlyTestCaseDir, READONLY_TYPE_GENERATION_FLAGS));
         }
     }
 });

--- a/src/commands/generate/__tests__/resources/constants.ts
+++ b/src/commands/generate/__tests__/resources/constants.ts
@@ -1,7 +1,7 @@
 import { ITypeGenerationFlags } from "../../typeGenerationFlags";
 
-export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false };
+export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyCollections: false, readonlyInterfaces: false };
 
 export const FLAVORED_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, flavorizedAliases: true };
 
-export const READONLY_COLLECTION_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true };
+export const READONLY_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, readonlyCollections: true, readonlyInterfaces: true };

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/backingFileSystem.ts
@@ -2,7 +2,7 @@ export interface IBackingFileSystem {
     /**
      * The name by which this file system is identified.
      */
-    'fileSystemId': string;
-    'baseUri': string;
-    'configuration': { readonly [key: string]: string };
+    readonly 'fileSystemId': string;
+    readonly 'baseUri': string;
+    readonly 'configuration': { readonly [key: string]: string };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product-datasets/dataset.ts
@@ -1,7 +1,7 @@
 export interface IDataset {
-    'fileSystemId': string;
+    readonly 'fileSystemId': string;
     /**
      * Uniquely identifies this dataset.
      */
-    'rid': string;
+    readonly 'rid': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/product/createDatasetRequest.ts
@@ -1,4 +1,4 @@
 export interface ICreateDatasetRequest {
-    'fileSystemId': string;
-    'path': string;
+    readonly 'fileSystemId': string;
+    readonly 'path': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/aliasAsMapKeyExample.ts
@@ -1,11 +1,11 @@
 import { IManyFieldExample } from "./manyFieldExample";
 
 export interface IAliasAsMapKeyExample {
-    'strings': { readonly [key: string]: IManyFieldExample };
-    'rids': { readonly [key: string]: IManyFieldExample };
-    'bearertokens': { readonly [key: string]: IManyFieldExample };
-    'integers': { readonly [key: string]: IManyFieldExample };
-    'safelongs': { readonly [key: string]: IManyFieldExample };
-    'datetimes': { readonly [key: string]: IManyFieldExample };
-    'uuids': { readonly [key: string]: IManyFieldExample };
+    readonly 'strings': { readonly [key: string]: IManyFieldExample };
+    readonly 'rids': { readonly [key: string]: IManyFieldExample };
+    readonly 'bearertokens': { readonly [key: string]: IManyFieldExample };
+    readonly 'integers': { readonly [key: string]: IManyFieldExample };
+    readonly 'safelongs': { readonly [key: string]: IManyFieldExample };
+    readonly 'datetimes': { readonly [key: string]: IManyFieldExample };
+    readonly 'uuids': { readonly [key: string]: IManyFieldExample };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyExample.ts
@@ -1,3 +1,3 @@
 export interface IAnyExample {
-    'any': any;
+    readonly 'any': any;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/anyMapExample.ts
@@ -1,3 +1,3 @@
 export interface IAnyMapExample {
-    'items': { readonly [key: string]: any };
+    readonly 'items': { readonly [key: string]: any };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/bearerTokenExample.ts
@@ -1,3 +1,3 @@
 export interface IBearerTokenExample {
-    'bearerTokenValue': string;
+    readonly 'bearerTokenValue': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/binaryExample.ts
@@ -1,3 +1,3 @@
 export interface IBinaryExample {
-    'binary': string;
+    readonly 'binary': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/booleanExample.ts
@@ -1,3 +1,3 @@
 export interface IBooleanExample {
-    'coin': boolean;
+    readonly 'coin': boolean;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantListExample.ts
@@ -1,4 +1,4 @@
 export interface ICovariantListExample {
-    'items': ReadonlyArray<any>;
-    'externalItems': ReadonlyArray<string>;
+    readonly 'items': ReadonlyArray<any>;
+    readonly 'externalItems': ReadonlyArray<string>;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/covariantOptionalExample.ts
@@ -1,3 +1,3 @@
 export interface ICovariantOptionalExample {
-    'item'?: any | null;
+    readonly 'item'?: any | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/dateTimeExample.ts
@@ -1,3 +1,3 @@
 export interface IDateTimeExample {
-    'datetime': string;
+    readonly 'datetime': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedFieldExample.ts
@@ -1,20 +1,20 @@
 export interface IDeprecatedFieldExample {
-    'one': string;
+    readonly 'one': string;
     /**
      * @deprecated use ONE
      */
-    'deprecatedOne': string;
+    readonly 'deprecatedOne': string;
     /**
      * You should no longer use this
      * 
      * @deprecated use ONE
      */
-    'documentedDeprecatedOne': string;
+    readonly 'documentedDeprecatedOne': string;
     /**
      * You should no longer use this
      * 
      * @deprecated should use ONE
      * 
      */
-    'deprecatedWithinDocumentOne': string;
+    readonly 'deprecatedWithinDocumentOne': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
@@ -1,14 +1,14 @@
 export interface IDeprecatedUnion_Good {
-    'good': string;
-    'type': "good";
+    readonly 'good': string;
+    readonly 'type': "good";
 }
 
 /**
  * @deprecated use good
  */
 export interface IDeprecatedUnion_NoGood {
-    'noGood': string;
-    'type': "noGood";
+    readonly 'noGood': string;
+    readonly 'type': "noGood";
 }
 
 /**
@@ -16,8 +16,8 @@ export interface IDeprecatedUnion_NoGood {
  * @deprecated use good
  */
 export interface IDeprecatedUnion_NoGoodDoc {
-    'noGoodDoc': string;
-    'type': "noGoodDoc";
+    readonly 'noGoodDoc': string;
+    readonly 'type': "noGoodDoc";
 }
 
 function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
@@ -62,10 +62,10 @@ function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
 export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
 
 export interface IDeprecatedUnionVisitor<T> {
-    'good': (obj: string) => T;
-    'noGood': (obj: string) => T;
-    'noGoodDoc': (obj: string) => T;
-    'unknown': (obj: IDeprecatedUnion) => T;
+    readonly 'good': (obj: string) => T;
+    readonly 'noGood': (obj: string) => T;
+    readonly 'noGoodDoc': (obj: string) => T;
+    readonly 'unknown': (obj: IDeprecatedUnion) => T;
 }
 
 function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/doubleExample.ts
@@ -1,3 +1,3 @@
 export interface IDoubleExample {
-    'doubleValue': number | "NaN";
+    readonly 'doubleValue': number | "NaN";
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/enumFieldExample.ts
@@ -1,5 +1,5 @@
 import { EnumExample } from "./enumExample";
 
 export interface IEnumFieldExample {
-    'enum': EnumExample;
+    readonly 'enum': EnumExample;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/externalLongExample.ts
@@ -1,5 +1,5 @@
 export interface IExternalLongExample {
-    'externalLong': number;
-    'optionalExternalLong'?: number | null;
-    'listExternalLong': ReadonlyArray<number>;
+    readonly 'externalLong': number;
+    readonly 'optionalExternalLong'?: number | null;
+    readonly 'listExternalLong': ReadonlyArray<number>;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/integerExample.ts
@@ -1,3 +1,3 @@
 export interface IIntegerExample {
-    'integer': number;
+    readonly 'integer': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/listExample.ts
@@ -1,5 +1,5 @@
 export interface IListExample {
-    'items': ReadonlyArray<string>;
-    'primitiveItems': ReadonlyArray<number>;
-    'doubleItems': ReadonlyArray<number | "NaN">;
+    readonly 'items': ReadonlyArray<string>;
+    readonly 'primitiveItems': ReadonlyArray<number>;
+    readonly 'doubleItems': ReadonlyArray<number | "NaN">;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/manyFieldExample.ts
@@ -2,33 +2,33 @@ export interface IManyFieldExample {
     /**
      * docs for string field
      */
-    'string': string;
+    readonly 'string': string;
     /**
      * docs for integer field
      */
-    'integer': number;
+    readonly 'integer': number;
     /**
      * docs for doubleValue field
      */
-    'doubleValue': number | "NaN";
+    readonly 'doubleValue': number | "NaN";
     /**
      * docs for optionalItem field
      */
-    'optionalItem'?: string | null;
+    readonly 'optionalItem'?: string | null;
     /**
      * docs for items field
      */
-    'items': ReadonlyArray<string>;
+    readonly 'items': ReadonlyArray<string>;
     /**
      * docs for set field
      */
-    'set': ReadonlyArray<string>;
+    readonly 'set': ReadonlyArray<string>;
     /**
      * docs for map field
      */
-    'map': { readonly [key: string]: string };
+    readonly 'map': { readonly [key: string]: string };
     /**
      * docs for alias field
      */
-    'alias': string;
+    readonly 'alias': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/mapExample.ts
@@ -1,3 +1,3 @@
 export interface IMapExample {
-    'items': { readonly [key: string]: string };
+    readonly 'items': { readonly [key: string]: string };
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/optionalExample.ts
@@ -1,3 +1,3 @@
 export interface IOptionalExample {
-    'item'?: string | null;
+    readonly 'item'?: string | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/primitiveOptionalsExample.ts
@@ -1,9 +1,9 @@
 export interface IPrimitiveOptionalsExample {
-    'num'?: number | "NaN" | null;
-    'bool'?: boolean | null;
-    'integer'?: number | null;
-    'safelong'?: number | null;
-    'rid'?: string | null;
-    'bearertoken'?: string | null;
-    'uuid'?: string | null;
+    readonly 'num'?: number | "NaN" | null;
+    readonly 'bool'?: boolean | null;
+    readonly 'integer'?: number | null;
+    readonly 'safelong'?: number | null;
+    readonly 'rid'?: string | null;
+    readonly 'bearertoken'?: string | null;
+    readonly 'uuid'?: string | null;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/reservedKeyExample.ts
@@ -1,7 +1,7 @@
 export interface IReservedKeyExample {
-    'package': string;
-    'interface': string;
-    'field-name-with-dashes': string;
-    'primitve-field-name-with-dashes': number;
-    'memoizedHashCode': number;
+    readonly 'package': string;
+    readonly 'interface': string;
+    readonly 'field-name-with-dashes': string;
+    readonly 'primitve-field-name-with-dashes': number;
+    readonly 'memoizedHashCode': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/ridExample.ts
@@ -1,3 +1,3 @@
 export interface IRidExample {
-    'ridValue': string;
+    readonly 'ridValue': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/safeLongExample.ts
@@ -1,3 +1,3 @@
 export interface ISafeLongExample {
-    'safeLongValue': number;
+    readonly 'safeLongValue': number;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/setExample.ts
@@ -1,4 +1,4 @@
 export interface ISetExample {
-    'items': ReadonlyArray<string>;
-    'doubleItems': ReadonlyArray<number | "NaN">;
+    readonly 'items': ReadonlyArray<string>;
+    readonly 'doubleItems': ReadonlyArray<number | "NaN">;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
@@ -1,6 +1,6 @@
 export interface ISingleUnion_Foo {
-    'foo': string;
-    'type': "foo";
+    readonly 'foo': string;
+    readonly 'type': "foo";
 }
 
 function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
@@ -17,8 +17,8 @@ function foo(obj: string): ISingleUnion_Foo {
 export type ISingleUnion = ISingleUnion_Foo;
 
 export interface ISingleUnionVisitor<T> {
-    'foo': (obj: string) => T;
-    'unknown': (obj: ISingleUnion) => T;
+    readonly 'foo': (obj: string) => T;
+    readonly 'unknown': (obj: ISingleUnion) => T;
 }
 
 function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/stringExample.ts
@@ -1,3 +1,3 @@
 export interface IStringExample {
-    'string': string;
+    readonly 'string': string;
 }

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
@@ -1,16 +1,16 @@
 export interface IUnion_Foo {
-    'foo': string;
-    'type': "foo";
+    readonly 'foo': string;
+    readonly 'type': "foo";
 }
 
 export interface IUnion_Bar {
-    'bar': number;
-    'type': "bar";
+    readonly 'bar': number;
+    readonly 'type': "bar";
 }
 
 export interface IUnion_Baz {
-    'baz': number;
-    'type': "baz";
+    readonly 'baz': number;
+    readonly 'type': "baz";
 }
 
 function isFoo(obj: IUnion): obj is IUnion_Foo {
@@ -49,10 +49,10 @@ function baz(obj: number): IUnion_Baz {
 export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
 
 export interface IUnionVisitor<T> {
-    'foo': (obj: string) => T;
-    'bar': (obj: number) => T;
-    'baz': (obj: number) => T;
-    'unknown': (obj: IUnion) => T;
+    readonly 'foo': (obj: string) => T;
+    readonly 'bar': (obj: number) => T;
+    readonly 'baz': (obj: number) => T;
+    readonly 'unknown': (obj: IUnion) => T;
 }
 
 function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
@@ -4,38 +4,38 @@ import { IStringExample } from "./stringExample";
  * Docs for when UnionTypeExample is of type StringExample.
  */
 export interface IUnionTypeExample_StringExample {
-    'stringExample': IStringExample;
-    'type': "stringExample";
+    readonly 'stringExample': IStringExample;
+    readonly 'type': "stringExample";
 }
 
 export interface IUnionTypeExample_Set {
-    'set': ReadonlyArray<string>;
-    'type': "set";
+    readonly 'set': ReadonlyArray<string>;
+    readonly 'type': "set";
 }
 
 export interface IUnionTypeExample_ThisFieldIsAnInteger {
-    'thisFieldIsAnInteger': number;
-    'type': "thisFieldIsAnInteger";
+    readonly 'thisFieldIsAnInteger': number;
+    readonly 'type': "thisFieldIsAnInteger";
 }
 
 export interface IUnionTypeExample_AlsoAnInteger {
-    'alsoAnInteger': number;
-    'type': "alsoAnInteger";
+    readonly 'alsoAnInteger': number;
+    readonly 'type': "alsoAnInteger";
 }
 
 export interface IUnionTypeExample_If {
-    'if': number;
-    'type': "if";
+    readonly 'if': number;
+    readonly 'type': "if";
 }
 
 export interface IUnionTypeExample_New {
-    'new': number;
-    'type': "new";
+    readonly 'new': number;
+    readonly 'type': "new";
 }
 
 export interface IUnionTypeExample_Interface {
-    'interface': number;
-    'type': "interface";
+    readonly 'interface': number;
+    readonly 'type': "interface";
 }
 
 function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
@@ -121,14 +121,14 @@ function interface_(obj: number): IUnionTypeExample_Interface {
 export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
 
 export interface IUnionTypeExampleVisitor<T> {
-    'stringExample': (obj: IStringExample) => T;
-    'set': (obj: ReadonlyArray<string>) => T;
-    'thisFieldIsAnInteger': (obj: number) => T;
-    'alsoAnInteger': (obj: number) => T;
-    'if': (obj: number) => T;
-    'new': (obj: number) => T;
-    'interface': (obj: number) => T;
-    'unknown': (obj: IUnionTypeExample) => T;
+    readonly 'stringExample': (obj: IStringExample) => T;
+    readonly 'set': (obj: ReadonlyArray<string>) => T;
+    readonly 'thisFieldIsAnInteger': (obj: number) => T;
+    readonly 'alsoAnInteger': (obj: number) => T;
+    readonly 'if': (obj: number) => T;
+    readonly 'new': (obj: number) => T;
+    readonly 'interface': (obj: number) => T;
+    readonly 'unknown': (obj: IUnionTypeExample) => T;
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/uuidExample.ts
@@ -1,3 +1,3 @@
 export interface IUuidExample {
-    'uuid': string;
+    readonly 'uuid': string;
 }

--- a/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
+++ b/src/commands/generate/__tests__/tsArgumentTypeVisitorTests.ts
@@ -18,7 +18,7 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsArgumentTypeVisitor } from "../tsArgumentTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("TsTypeVisitor", () => {
     const aliasName = { name: "Alias", package: "" };
@@ -179,7 +179,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             false,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         const topLevelVisitor = new TsArgumentTypeVisitor(
@@ -189,7 +189,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             true,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         it("returns list type", () => {

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -18,7 +18,7 @@
 import { IType, ITypeDefinition, PrimitiveType } from "conjure-api";
 import { TsReturnTypeVisitor } from "../tsReturnTypeVisitor";
 import { createHashableTypeName } from "../utils";
-import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_COLLECTION_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { DEFAULT_TYPE_GENERATION_FLAGS, FLAVORED_TYPE_GENERATION_FLAGS, READONLY_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 const objectName = { name: "Object", package: "" };
 const objectReference = IType.reference(objectName);
@@ -229,7 +229,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             false,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         const topLevelVisitor = new TsReturnTypeVisitor(
@@ -241,7 +241,7 @@ describe("TsTypeVisitor", () => {
             ]),
             fakeTypeName,
             true,
-            READONLY_COLLECTION_TYPE_GENERATION_FLAGS,
+            READONLY_TYPE_GENERATION_FLAGS,
         );
 
         it("returns list type", () => {

--- a/src/commands/generate/errorGenerator.ts
+++ b/src/commands/generate/errorGenerator.ts
@@ -53,18 +53,22 @@ export function generateError(
             {
                 name: singleQuote("errorCode"),
                 type: doubleQuote(definition.code),
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("errorInstanceId"),
                 type: "string",
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("errorName"),
                 type: doubleQuote(errorName),
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
             {
                 name: singleQuote("parameters"),
                 type: `{\n${properties}}`,
+                isReadonly: typeGenerationFlags.readonlyInterfaces,
             },
         ],
     });

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -63,6 +63,11 @@ export interface IGenerateCommandArgs {
      * Generated interfaces use ReadonlyArray instead of Array and readonly map patterns
      */
     readonlyCollections?: boolean;
+
+    /**
+     * Generated interfaces have readonly properties
+     */
+    readonlyInterfaces?: boolean;
 }
 
 interface ICleanedGenerateCommandArgs {
@@ -123,6 +128,11 @@ export class GenerateCommand implements CommandModule {
                 describe: "Generated interfaces use ReadonlyArray instead of Array and readonly map patterns",
                 type: "boolean",
             })
+            .option("readonlyInterfaces", {
+                default: false,
+                describe: "Generated interfaces have readonly properties",
+                type: "boolean",
+            })
             .option("productDependencies", {
                 default: undefined,
                 describe: "Path to a file containing a list of product dependencies",
@@ -138,6 +148,7 @@ export class GenerateCommand implements CommandModule {
         const generatePromise = generate(conjureDefinition, output, {
             flavorizedAliases: args.flavorizedAliases ?? false,
             readonlyCollections: args.readonlyCollections ?? false,
+            readonlyInterfaces: args.readonlyInterfaces ?? false,
         });
         if (rawSource) {
             return generatePromise;

--- a/src/commands/generate/typeGenerationFlags.ts
+++ b/src/commands/generate/typeGenerationFlags.ts
@@ -28,4 +28,9 @@ export interface ITypeGenerationFlags {
      * Generated interfaces use ReadonlyArray instead of Array.
      */
     readonly readonlyCollections: boolean;
+
+    /**
+     * Generated interfaces have readonly properties.
+     */
+    readonly readonlyInterfaces: boolean;
 }

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -197,6 +197,7 @@ export async function generateObject(
             name: singleQuote(fieldDefinition.fieldName),
             type: fieldType,
             docs: addDeprecatedToDocs(fieldDefinition),
+            isReadonly: typeGenerationFlags.readonlyInterfaces,
         };
 
         properties.push(property);
@@ -325,10 +326,12 @@ function processUnionMembers(
                 {
                     name: singleQuote(memberName),
                     type: fieldType,
+                    isReadonly: typeGenerationFlags.readonlyInterfaces,
                 },
                 {
                     name: singleQuote("type"),
                     type: doubleQuote(memberName),
+                    isReadonly: typeGenerationFlags.readonlyInterfaces,
                 },
             ],
         });
@@ -372,6 +375,7 @@ function processUnionMembers(
         visitorProperties.push({
             name: singleQuote(memberName),
             type: `(obj: ${fieldType}) => T`,
+            isReadonly: typeGenerationFlags.readonlyInterfaces,
         });
         visitorStatements.push(`if (${typeGuard.name}(${obj})) {
             return ${visitor}.${memberName}(${obj}.${memberName});
@@ -381,6 +385,7 @@ function processUnionMembers(
     visitorProperties.push({
         name: singleQuote("unknown"),
         type: `(obj: ${unionTsType}) => T`,
+        isReadonly: typeGenerationFlags.readonlyInterfaces,
     });
     visitorStatements.push(`return ${visitor}.unknown(${obj});`);
 


### PR DESCRIPTION
Builds on #219, fixes nice to have from #155 

## Before this PR
Conjure interfaces are difficult to work with in projects with stricter readonly usage, in particularly when storing results or generating API calls from (ideally) immutable state like redux.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
This makes all properties on generated conjure objects declared as readonly.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This has the same compatibility issues as `flavoredAliases` and `readonlyCollections`.

