### PR TITLE
Carry Configured Service Optionality Through to Generated package.json

### DIFF
--- a/changelog/@unreleased/pr-238.v2.yml
+++ b/changelog/@unreleased/pr-238.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Carry Configured Service Optionality Through to Generated package.json
+
+    ## Before this PR
+    Service optionality was completely ignored
+
+    ## After this PR
+    Now if you configure something as optional it should be reflected in the TS dep (this is already true for Java)
+
+    ## Possible downsides?
+    Doesn't generate retroactively, so there is probably tons of boilerplate
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/238

--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -65,6 +65,48 @@ describe("generate command", () => {
                     "minimum-version": "1.0.0",
                     "recommended-version": "1.2.0",
                     "maximum-version": "2.x.x",
+                },
+            ];
+            const productDependencyPath = path.join(outDir, "productDependencies.json");
+            await fs.writeJSON(productDependencyPath, productDependencies);
+            const expectedPackageJson = {
+                name: "foo",
+                version: "1.0.0",
+                sls: {
+                    dependencies: {
+                        "com.palantir.conjure:conjure": {
+                            minVersion: "1.0.0",
+                            recommendedVersion: "1.2.0",
+                            maxVersion: "2.x.x",
+                        },
+                    },
+                },
+                main: "index.js",
+                types: "index.d.ts",
+                sideEffects: false,
+                scripts: {
+                    build: "tsc",
+                },
+                dependencies: { "conjure-client": "1.0.0" },
+                devDependencies: {
+                    typescript: "2.7.2",
+                },
+                author: "Conjure",
+                license: "UNLICENSED",
+            };
+            expect(await createPackageJson(inputPackage, "foo", "1.0.0", productDependencyPath)).toEqual(
+                expectedPackageJson,
+            );
+        });
+
+        it("generate packageJson with productDependencies with specified optional", async () => {
+            const productDependencies: ISlsManifestDependency[] = [
+                {
+                    "product-group": "com.palantir.conjure",
+                    "product-name": "conjure",
+                    "minimum-version": "1.0.0",
+                    "recommended-version": "1.2.0",
+                    "maximum-version": "2.x.x",
                     "optional": false,
                 },
             ];

--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -108,7 +108,7 @@ describe("generate command", () => {
                     "product-name": "conjure",
                     "minimum-version": "1.0.0",
                     "maximum-version": "2.x.x",
-                    "optional": false,
+                    "optional": true,
                 },
             ];
             const productDependencyPath = path.join(outDir, "productDependencies.json");
@@ -121,7 +121,7 @@ describe("generate command", () => {
                         "com.palantir.conjure:conjure": {
                             minVersion: "1.0.0",
                             maxVersion: "2.x.x",
-                            optional: false,
+                            optional: true,
                         },
                     },
                 },

--- a/src/commands/generate/__tests__/cliTest.ts
+++ b/src/commands/generate/__tests__/cliTest.ts
@@ -65,6 +65,7 @@ describe("generate command", () => {
                     "minimum-version": "1.0.0",
                     "recommended-version": "1.2.0",
                     "maximum-version": "2.x.x",
+                    "optional": false,
                 },
             ];
             const productDependencyPath = path.join(outDir, "productDependencies.json");
@@ -78,6 +79,7 @@ describe("generate command", () => {
                             minVersion: "1.0.0",
                             recommendedVersion: "1.2.0",
                             maxVersion: "2.x.x",
+                            optional: false,
                         },
                     },
                 },
@@ -106,6 +108,7 @@ describe("generate command", () => {
                     "product-name": "conjure",
                     "minimum-version": "1.0.0",
                     "maximum-version": "2.x.x",
+                    "optional": false,
                 },
             ];
             const productDependencyPath = path.join(outDir, "productDependencies.json");
@@ -118,6 +121,7 @@ describe("generate command", () => {
                         "com.palantir.conjure:conjure": {
                             minVersion: "1.0.0",
                             maxVersion: "2.x.x",
+                            optional: false,
                         },
                     },
                 },

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -222,7 +222,7 @@ export async function resolveProductDependencies(
         const coordinate = `${productDependency["product-group"]}:${productDependency["product-name"]}`;
         const minVersion = productDependency["minimum-version"];
         const maxVersion = productDependency["maximum-version"];
-        const optional = productDependency["optional"];
+        const optional = productDependency.optional;
         const recommendedVersion = productDependency["recommended-version"];
         if (
             !SlsVersion.isValid(minVersion) ||

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -222,6 +222,7 @@ export async function resolveProductDependencies(
         const coordinate = `${productDependency["product-group"]}:${productDependency["product-name"]}`;
         const minVersion = productDependency["minimum-version"];
         const maxVersion = productDependency["maximum-version"];
+        const optional = productDependency["optional"];
         const recommendedVersion = productDependency["recommended-version"];
         if (
             !SlsVersion.isValid(minVersion) ||
@@ -233,6 +234,7 @@ export async function resolveProductDependencies(
         dependencies[coordinate] = {
             minVersion,
             maxVersion,
+            optional,
             recommendedVersion,
         };
     });

--- a/src/utils/slslDependencies.ts
+++ b/src/utils/slslDependencies.ts
@@ -8,12 +8,14 @@ export interface ISlsManifestDependency {
     "minimum-version": string;
     "maximum-version": string;
     "recommended-version"?: string;
-    "optional": boolean;
+    // Optional for backcompat
+    "optional"?: boolean;
 }
 
 export interface IProductDependency {
     minVersion: string;
     maxVersion: string;
-    optional: boolean;
+    // Optional for backcompat
+    optional?: boolean;
     recommendedVersion?: string;
 }

--- a/src/utils/slslDependencies.ts
+++ b/src/utils/slslDependencies.ts
@@ -8,10 +8,12 @@ export interface ISlsManifestDependency {
     "minimum-version": string;
     "maximum-version": string;
     "recommended-version"?: string;
+    "optional": boolean;
 }
 
 export interface IProductDependency {
     minVersion: string;
     maxVersion: string;
+    optional: boolean;
     recommendedVersion?: string;
 }


### PR DESCRIPTION
## Before this PR
Service optionality was completely ignored

## After this PR
Now if you configure something as optional it should be reflected in the TS dep (this is already true for Java)

## Possible downsides?
Doesn't generate retroactively, so there is probably tons of boilerplate

