### PR TITLE
Generate Functions and other Code Slimming Features

### DIFF
--- a/src/commands/generate/__tests__/resources/constants.ts
+++ b/src/commands/generate/__tests__/resources/constants.ts
@@ -1,6 +1,6 @@
 import { ITypeGenerationFlags } from "../../typeGenerationFlags";
 
-export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyInterfaces: false };
+export const DEFAULT_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { flavorizedAliases: false, readonlyInterfaces: false, omitServiceMetadata: false, omitUnnecessaryArgs: false, omitServiceClasses: false};
 
 export const FLAVORED_TYPE_GENERATION_FLAGS: ITypeGenerationFlags = { ...DEFAULT_TYPE_GENERATION_FLAGS, flavorizedAliases: true };
 

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-binary-types/binary/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-binary-types/binary/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-service/another/testService.ts
@@ -1,0 +1,567 @@
+import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
+import { IDataset } from "../product-datasets/dataset";
+import { IAliasedString } from "../product/aliasedString";
+import { ICreateDatasetRequest } from "../product/createDatasetRequest";
+import { IHttpApiBridge } from "conjure-client";
+
+/** Constant references that we expect to get minified and therefore reduce total code size */
+const __undefined: undefined = undefined, __emptyString: string = "";
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ [key: string]: IBackingFileSystem }> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IAliasedString> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * A Markdown description of the service.
+ *
+ */
+export interface ITestService {
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     *
+     */
+    getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }>;
+    createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
+    getDataset(datasetRid: string): Promise<IDataset | null>;
+    getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null>;
+    getAliasedString(datasetRid: string): Promise<IAliasedString>;
+    uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    getBranches(datasetRid: string): Promise<Array<string>>;
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @deprecated use getBranches instead
+     */
+    getBranchesDeprecated(datasetRid: string): Promise<Array<string>>;
+    resolveBranch(datasetRid: string, branch: string): Promise<string | null>;
+    testParam(datasetRid: string): Promise<string | null>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
+    testBoolean(): Promise<boolean>;
+    testDouble(): Promise<number | "NaN">;
+    testInteger(): Promise<number>;
+    testPostOptional(maybeString?: string | null): Promise<string | null>;
+    testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void>;
+}
+
+export class TestService {
+    constructor(private bridge: IHttpApiBridge) {
+    }
+
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     *
+     */
+    public getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }> {
+        return this.bridge.call<{ [key: string]: IBackingFileSystem }>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/fileSystems",
+        );
+    }
+
+    public createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+        return this.bridge.call<IDataset>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets",
+            request,
+            {
+                "Test-Header": testHeaderArg,
+            },
+        );
+    }
+
+    public getDataset(datasetRid: string): Promise<IDataset | null> {
+        return this.bridge.call<IDataset | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+        return this.bridge.call<ReadableStream<Uint8Array> | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-maybe",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedString(datasetRid: string): Promise<IAliasedString> {
+        return this.bridge.call<IAliasedString>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/string-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets/upload-raw",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+        );
+    }
+
+    public uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets/upload-raw-aliased",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+        );
+    }
+
+    public getBranches(datasetRid: string): Promise<Array<string>> {
+        return this.bridge.call<Array<string>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @deprecated use getBranches instead
+     */
+    public getBranchesDeprecated(datasetRid: string): Promise<Array<string>> {
+        return this.bridge.call<Array<string>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branchesDeprecated",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public resolveBranch(datasetRid: string, branch: string): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+
+                branch,
+            ],
+        );
+    }
+
+    public testParam(datasetRid: string): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/testParam",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+        return this.bridge.call<number>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/test-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+        );
+    }
+
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/test-no-response-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+        );
+    }
+
+    public testBoolean(): Promise<boolean> {
+        return this.bridge.call<boolean>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/boolean",
+        );
+    }
+
+    public testDouble(): Promise<number | "NaN"> {
+        return this.bridge.call<number | "NaN">(__emptyString, __emptyString,
+            "GET",
+            "/catalog/double",
+        );
+    }
+
+    public testInteger(): Promise<number> {
+        return this.bridge.call<number>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/integer",
+        );
+    }
+
+    public testPostOptional(maybeString?: string | null): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/optional",
+            maybeString,
+        );
+    }
+
+    public testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/optional-integer-double",
+            __undefined,
+            __undefined,
+            {
+                "maybeInteger": maybeInteger,
+
+                "maybeDouble": maybeDouble,
+            },
+        );
+    }
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-service/product-datasets/backingFileSystem.ts
@@ -1,0 +1,6 @@
+export interface IBackingFileSystem {
+    /** The name by which this file system is identified. */
+    'fileSystemId': string;
+    'baseUri': string;
+    'configuration': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-service/product-datasets/dataset.ts
@@ -1,0 +1,5 @@
+export interface IDataset {
+    'fileSystemId': string;
+    /** Uniquely identifies this dataset. */
+    'rid': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-service/product/aliasedString.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-service/product/aliasedString.ts
@@ -1,0 +1,4 @@
+export type IAliasedString = string & {
+    __conjure_type?: "AliasedString",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-service/product/createDatasetRequest.ts
@@ -1,0 +1,4 @@
+export interface ICreateDatasetRequest {
+    'fileSystemId': string;
+    'path': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/aliasAsMapKeyExample.ts
@@ -1,0 +1,17 @@
+import { IBearerTokenAliasExample } from "./bearerTokenAliasExample";
+import { IIntegerAliasExample } from "./integerAliasExample";
+import { IManyFieldExample } from "./manyFieldExample";
+import { IRidAliasExample } from "./ridAliasExample";
+import { ISafeLongAliasExample } from "./safeLongAliasExample";
+import { IStringAliasExample } from "./stringAliasExample";
+import { IUuidAliasExample } from "./uuidAliasExample";
+
+export interface IAliasAsMapKeyExample {
+    'strings': { [key: IStringAliasExample]: IManyFieldExample };
+    'rids': { [key: IRidAliasExample]: IManyFieldExample };
+    'bearertokens': { [key: IBearerTokenAliasExample]: IManyFieldExample };
+    'integers': { [key: IIntegerAliasExample]: IManyFieldExample };
+    'safelongs': { [key: ISafeLongAliasExample]: IManyFieldExample };
+    'datetimes': { [key: string]: IManyFieldExample };
+    'uuids': { [key: IUuidAliasExample]: IManyFieldExample };
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/anyExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyExample {
+    'any': any;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/anyMapExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyMapExample {
+    'items': { [key: string]: any };
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerAliasExample = string & {
+    __conjure_type?: "BearerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerTokenAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerTokenAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerTokenAliasExample = string & {
+    __conjure_type?: "BearerTokenAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/bearerTokenExample.ts
@@ -1,0 +1,3 @@
+export interface IBearerTokenExample {
+    'bearerTokenValue': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/booleanExample.ts
@@ -1,0 +1,3 @@
+export interface IBooleanExample {
+    'coin': boolean;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/covariantListExample.ts
@@ -1,0 +1,4 @@
+export interface ICovariantListExample {
+    'items': Array<any>;
+    'externalItems': Array<string>;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/covariantOptionalExample.ts
@@ -1,0 +1,3 @@
+export interface ICovariantOptionalExample {
+    'item'?: any | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/dateTimeExample.ts
@@ -1,0 +1,3 @@
+export interface IDateTimeExample {
+    'datetime': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedEnumExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedEnumExample.ts
@@ -1,0 +1,25 @@
+export namespace DeprecatedEnumExample {
+    export type ONE = "ONE";
+    /** @deprecated use ONE */
+    export type OLD_ONE = "OLD_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    export type OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    export type OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE";
+
+    export const ONE = "ONE" as "ONE";
+    export const OLD_ONE = "OLD_ONE" as "OLD_ONE";
+    export const OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE" as "OLD_DEPRECATED_ONE";
+    export const OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE" as "OLD_DOCUMENTED_ONE";
+}
+
+export type DeprecatedEnumExample = keyof typeof DeprecatedEnumExample;

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedFieldExample.ts
@@ -1,0 +1,18 @@
+export interface IDeprecatedFieldExample {
+    'one': string;
+    /** @deprecated use ONE */
+    'deprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    'documentedDeprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    'deprecatedWithinDocumentOne': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/deprecatedUnion.ts
@@ -1,0 +1,86 @@
+export interface IDeprecatedUnion_Good {
+    'good': string;
+    'type': "good";
+}
+
+/** @deprecated use good */
+export interface IDeprecatedUnion_NoGood {
+    'noGood': string;
+    'type': "noGood";
+}
+
+/**
+ * this is no good
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGoodDoc {
+    'noGoodDoc': string;
+    'type': "noGoodDoc";
+}
+
+function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
+    return (obj.type === "good");
+}
+
+function good(obj: string): IDeprecatedUnion_Good {
+    return {
+        good: obj,
+        type: "good",
+    };
+}
+
+function isNoGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGood {
+    return (obj.type === "noGood");
+}
+
+/** @deprecated use good */
+function noGood(obj: string): IDeprecatedUnion_NoGood {
+    return {
+        noGood: obj,
+        type: "noGood",
+    };
+}
+
+function isNoGoodDoc(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGoodDoc {
+    return (obj.type === "noGoodDoc");
+}
+
+/** @deprecated use good */
+function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
+    return {
+        noGoodDoc: obj,
+        type: "noGoodDoc",
+    };
+}
+
+export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
+
+export interface IDeprecatedUnionVisitor<T> {
+    'good': (obj: string) => T;
+    'noGood': (obj: string) => T;
+    'noGoodDoc': (obj: string) => T;
+    'unknown': (obj: IDeprecatedUnion) => T;
+}
+
+function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
+    if (isGood(obj)) {
+        return visitor.good(obj.good);
+    }
+    if (isNoGood(obj)) {
+        return visitor.noGood(obj.noGood);
+    }
+    if (isNoGoodDoc(obj)) {
+        return visitor.noGoodDoc(obj.noGoodDoc);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IDeprecatedUnion = {
+    isGood: isGood,
+    good: good,
+    isNoGood: isNoGood,
+    noGood: noGood,
+    isNoGoodDoc: isNoGoodDoc,
+    noGoodDoc: noGoodDoc,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/doubleAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/doubleAliasExample.ts
@@ -1,0 +1,4 @@
+export type IDoubleAliasExample = number | "NaN" & {
+    __conjure_type?: "DoubleAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/doubleExample.ts
@@ -1,0 +1,3 @@
+export interface IDoubleExample {
+    'doubleValue': number | "NaN";
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/emptyEnum.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/emptyEnum.ts
@@ -1,0 +1,3 @@
+export const EmptyEnum = {};
+
+export type EmptyEnum = void;

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/emptyObjectExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/emptyObjectExample.ts
@@ -1,0 +1,2 @@
+export interface IEmptyObjectExample {
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/enumExample.ts
@@ -1,0 +1,16 @@
+/**
+ * This enumerates the numbers 1:2 also 100.
+ *
+ */
+export namespace EnumExample {
+    export type ONE = "ONE";
+    export type TWO = "TWO";
+    /** Value of 100. */
+    export type ONE_HUNDRED = "ONE_HUNDRED";
+
+    export const ONE = "ONE" as "ONE";
+    export const TWO = "TWO" as "TWO";
+    export const ONE_HUNDRED = "ONE_HUNDRED" as "ONE_HUNDRED";
+}
+
+export type EnumExample = keyof typeof EnumExample;

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/enumFieldExample.ts
@@ -1,0 +1,5 @@
+import { EnumExample } from "./enumExample";
+
+export interface IEnumFieldExample {
+    'enum': EnumExample;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/externalLongExample.ts
@@ -1,0 +1,5 @@
+export interface IExternalLongExample {
+    'externalLong': number;
+    'optionalExternalLong'?: number | null;
+    'listExternalLong': Array<number>;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/integerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/integerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IIntegerAliasExample = number & {
+    __conjure_type?: "IntegerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/integerExample.ts
@@ -1,0 +1,3 @@
+export interface IIntegerExample {
+    'integer': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/listExample.ts
@@ -1,0 +1,5 @@
+export interface IListExample {
+    'items': Array<string>;
+    'primitiveItems': Array<number>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/manyFieldExample.ts
@@ -1,0 +1,20 @@
+import { IStringAliasExample } from "./stringAliasExample";
+
+export interface IManyFieldExample {
+    /** docs for string field */
+    'string': string;
+    /** docs for integer field */
+    'integer': number;
+    /** docs for doubleValue field */
+    'doubleValue': number | "NaN";
+    /** docs for optionalItem field */
+    'optionalItem'?: string | null;
+    /** docs for items field */
+    'items': Array<string>;
+    /** docs for set field */
+    'set': Array<string>;
+    /** docs for map field */
+    'map': { [key: string]: string };
+    /** docs for alias field */
+    'alias': IStringAliasExample;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/mapExample.ts
@@ -1,0 +1,3 @@
+export interface IMapExample {
+    'items': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/primitiveOptionalsExample.ts
@@ -1,0 +1,9 @@
+export interface IPrimitiveOptionalsExample {
+    'num'?: number | "NaN" | null;
+    'bool'?: boolean | null;
+    'integer'?: number | null;
+    'safelong'?: number | null;
+    'rid'?: string | null;
+    'bearertoken'?: string | null;
+    'uuid'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/reservedKeyExample.ts
@@ -1,0 +1,7 @@
+export interface IReservedKeyExample {
+    'package': string;
+    'interface': string;
+    'field-name-with-dashes': string;
+    'primitve-field-name-with-dashes': number;
+    'memoizedHashCode': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/ridAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/ridAliasExample.ts
@@ -1,0 +1,4 @@
+export type IRidAliasExample = string & {
+    __conjure_type?: "RidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/ridExample.ts
@@ -1,0 +1,3 @@
+export interface IRidExample {
+    'ridValue': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/safeLongAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/safeLongAliasExample.ts
@@ -1,0 +1,4 @@
+export type ISafeLongAliasExample = number & {
+    __conjure_type?: "SafeLongAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/safeLongExample.ts
@@ -1,0 +1,3 @@
+export interface ISafeLongExample {
+    'safeLongValue': number;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/setExample.ts
@@ -1,0 +1,4 @@
+export interface ISetExample {
+    'items': Array<string>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/simpleEnum.ts
@@ -1,0 +1,7 @@
+export namespace SimpleEnum {
+    export type VALUE = "VALUE";
+
+    export const VALUE = "VALUE" as "VALUE";
+}
+
+export type SimpleEnum = keyof typeof SimpleEnum;

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/singleUnion.ts
@@ -1,0 +1,35 @@
+export interface ISingleUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): ISingleUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+export type ISingleUnion = ISingleUnion_Foo;
+
+export interface ISingleUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'unknown': (obj: ISingleUnion) => T;
+}
+
+function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    return visitor.unknown(obj);
+}
+
+export const ISingleUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringAliasExample.ts
@@ -1,0 +1,4 @@
+export type IStringAliasExample = string & {
+    __conjure_type?: "StringAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringAliasOne.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringAliasOne.ts
@@ -1,0 +1,4 @@
+export type IStringAliasOne = string & {
+    __conjure_type?: "StringAliasOne",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/stringExample.ts
@@ -1,0 +1,3 @@
+export interface IStringExample {
+    'string': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/union.ts
@@ -1,0 +1,79 @@
+export interface IUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+export interface IUnion_Bar {
+    'bar': number;
+    'type': "bar";
+}
+
+export interface IUnion_Baz {
+    'baz': number;
+    'type': "baz";
+}
+
+function isFoo(obj: IUnion): obj is IUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): IUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+function isBar(obj: IUnion): obj is IUnion_Bar {
+    return (obj.type === "bar");
+}
+
+function bar(obj: number): IUnion_Bar {
+    return {
+        bar: obj,
+        type: "bar",
+    };
+}
+
+function isBaz(obj: IUnion): obj is IUnion_Baz {
+    return (obj.type === "baz");
+}
+
+function baz(obj: number): IUnion_Baz {
+    return {
+        baz: obj,
+        type: "baz",
+    };
+}
+
+export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
+
+export interface IUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'bar': (obj: number) => T;
+    'baz': (obj: number) => T;
+    'unknown': (obj: IUnion) => T;
+}
+
+function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    if (isBar(obj)) {
+        return visitor.bar(obj.bar);
+    }
+    if (isBaz(obj)) {
+        return visitor.baz(obj.baz);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    isBar: isBar,
+    bar: bar,
+    isBaz: isBaz,
+    baz: baz,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/unionTypeExample.ts
@@ -1,0 +1,171 @@
+import { IStringExample } from "./stringExample";
+
+/** Docs for when UnionTypeExample is of type StringExample. */
+export interface IUnionTypeExample_StringExample {
+    'stringExample': IStringExample;
+    'type': "stringExample";
+}
+
+export interface IUnionTypeExample_Set {
+    'set': Array<string>;
+    'type': "set";
+}
+
+export interface IUnionTypeExample_ThisFieldIsAnInteger {
+    'thisFieldIsAnInteger': number;
+    'type': "thisFieldIsAnInteger";
+}
+
+export interface IUnionTypeExample_AlsoAnInteger {
+    'alsoAnInteger': number;
+    'type': "alsoAnInteger";
+}
+
+export interface IUnionTypeExample_If {
+    'if': number;
+    'type': "if";
+}
+
+export interface IUnionTypeExample_New {
+    'new': number;
+    'type': "new";
+}
+
+export interface IUnionTypeExample_Interface {
+    'interface': number;
+    'type': "interface";
+}
+
+function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
+    return (obj.type === "stringExample");
+}
+
+function stringExample(obj: IStringExample): IUnionTypeExample_StringExample {
+    return {
+        stringExample: obj,
+        type: "stringExample",
+    };
+}
+
+function isSet(obj: IUnionTypeExample): obj is IUnionTypeExample_Set {
+    return (obj.type === "set");
+}
+
+function set(obj: Array<string>): IUnionTypeExample_Set {
+    return {
+        set: obj,
+        type: "set",
+    };
+}
+
+function isThisFieldIsAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_ThisFieldIsAnInteger {
+    return (obj.type === "thisFieldIsAnInteger");
+}
+
+function thisFieldIsAnInteger(obj: number): IUnionTypeExample_ThisFieldIsAnInteger {
+    return {
+        thisFieldIsAnInteger: obj,
+        type: "thisFieldIsAnInteger",
+    };
+}
+
+function isAlsoAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_AlsoAnInteger {
+    return (obj.type === "alsoAnInteger");
+}
+
+function alsoAnInteger(obj: number): IUnionTypeExample_AlsoAnInteger {
+    return {
+        alsoAnInteger: obj,
+        type: "alsoAnInteger",
+    };
+}
+
+function isIf(obj: IUnionTypeExample): obj is IUnionTypeExample_If {
+    return (obj.type === "if");
+}
+
+function if_(obj: number): IUnionTypeExample_If {
+    return {
+        if: obj,
+        type: "if",
+    };
+}
+
+function isNew(obj: IUnionTypeExample): obj is IUnionTypeExample_New {
+    return (obj.type === "new");
+}
+
+function new_(obj: number): IUnionTypeExample_New {
+    return {
+        new: obj,
+        type: "new",
+    };
+}
+
+function isInterface(obj: IUnionTypeExample): obj is IUnionTypeExample_Interface {
+    return (obj.type === "interface");
+}
+
+function interface_(obj: number): IUnionTypeExample_Interface {
+    return {
+        interface: obj,
+        type: "interface",
+    };
+}
+
+/** A type which can either be a StringExample, a set of strings, or an integer. */
+export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
+
+export interface IUnionTypeExampleVisitor<T> {
+    'stringExample': (obj: IStringExample) => T;
+    'set': (obj: Array<string>) => T;
+    'thisFieldIsAnInteger': (obj: number) => T;
+    'alsoAnInteger': (obj: number) => T;
+    'if': (obj: number) => T;
+    'new': (obj: number) => T;
+    'interface': (obj: number) => T;
+    'unknown': (obj: IUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
+    if (isStringExample(obj)) {
+        return visitor.stringExample(obj.stringExample);
+    }
+    if (isSet(obj)) {
+        return visitor.set(obj.set);
+    }
+    if (isThisFieldIsAnInteger(obj)) {
+        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+    }
+    if (isAlsoAnInteger(obj)) {
+        return visitor.alsoAnInteger(obj.alsoAnInteger);
+    }
+    if (isIf(obj)) {
+        return visitor.if(obj.if);
+    }
+    if (isNew(obj)) {
+        return visitor.new(obj.new);
+    }
+    if (isInterface(obj)) {
+        return visitor.interface(obj.interface);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnionTypeExample = {
+    isStringExample: isStringExample,
+    stringExample: stringExample,
+    isSet: isSet,
+    set: set,
+    isThisFieldIsAnInteger: isThisFieldIsAnInteger,
+    thisFieldIsAnInteger: thisFieldIsAnInteger,
+    isAlsoAnInteger: isAlsoAnInteger,
+    alsoAnInteger: alsoAnInteger,
+    isIf: isIf,
+    if_: if_,
+    isNew: isNew,
+    new_: new_,
+    isInterface: isInterface,
+    interface_: interface_,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/uuidAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/uuidAliasExample.ts
@@ -1,0 +1,4 @@
+export type IUuidAliasExample = string & {
+    __conjure_type?: "UuidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-slim/example-types/product/uuidExample.ts
@@ -1,0 +1,3 @@
+export interface IUuidExample {
+    'uuid': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-binary-types/binary/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-binary-types/binary/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
@@ -4,8 +4,307 @@ import { IAliasedString } from "../product/aliasedString";
 import { ICreateDatasetRequest } from "../product/createDatasetRequest";
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ [key: string]: IBackingFileSystem }> {
+    return bridge(...[
+        "TestService",
+        "getFileSystems",
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[
+        "TestService",
+        "createDataset",
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[
+        "TestService",
+        "getDataset",
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getAliasedRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[
+        "TestService",
+        "maybeGetRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IAliasedString> {
+    return bridge(...[
+        "TestService",
+        "getAliasedString",
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadRawData",
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadAliasedRawData",
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranches",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranchesDeprecated",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "resolveBranch",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testParam",
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testQueryParams",
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testNoResponseQueryParams",
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[
+        "TestService",
+        "testBoolean",
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[
+        "TestService",
+        "testDouble",
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testInteger",
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testPostOptional",
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testOptionalIntegerAndDouble",
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}
 
 /**
  * A Markdown description of the service.

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-binary-types/binary/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-binary-types/binary/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-service/another/testService.ts
@@ -1,0 +1,567 @@
+import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
+import { IDataset } from "../product-datasets/dataset";
+import { IAliasedString } from "../product/aliasedString";
+import { ICreateDatasetRequest } from "../product/createDatasetRequest";
+import { IHttpApiBridge } from "conjure-client";
+
+/** Constant references that we expect to get minified and therefore reduce total code size */
+const __undefined: undefined = undefined, __emptyString: string = "";
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ [key: string]: IBackingFileSystem }> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IAliasedString> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * A Markdown description of the service.
+ *
+ */
+export interface ITestService {
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     *
+     */
+    getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }>;
+    createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset>;
+    getDataset(datasetRid: string): Promise<IDataset | null>;
+    getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>>;
+    maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null>;
+    getAliasedString(datasetRid: string): Promise<IAliasedString>;
+    uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void>;
+    getBranches(datasetRid: string): Promise<Array<string>>;
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @deprecated use getBranches instead
+     */
+    getBranchesDeprecated(datasetRid: string): Promise<Array<string>>;
+    resolveBranch(datasetRid: string, branch: string): Promise<string | null>;
+    testParam(datasetRid: string): Promise<string | null>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
+    testBoolean(): Promise<boolean>;
+    testDouble(): Promise<number | "NaN">;
+    testInteger(): Promise<number>;
+    testPostOptional(maybeString?: string | null): Promise<string | null>;
+    testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void>;
+}
+
+export class TestService {
+    constructor(private bridge: IHttpApiBridge) {
+    }
+
+    /**
+     * Returns a mapping from file system id to backing file system configuration.
+     *
+     */
+    public getFileSystems(): Promise<{ [key: string]: IBackingFileSystem }> {
+        return this.bridge.call<{ [key: string]: IBackingFileSystem }>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/fileSystems",
+        );
+    }
+
+    public createDataset(request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+        return this.bridge.call<IDataset>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets",
+            request,
+            {
+                "Test-Header": testHeaderArg,
+            },
+        );
+    }
+
+    public getDataset(datasetRid: string): Promise<IDataset | null> {
+        return this.bridge.call<IDataset | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public getRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedRawData(datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+        return this.bridge.call<ReadableStream<Uint8Array>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public maybeGetRawData(datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+        return this.bridge.call<ReadableStream<Uint8Array> | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/raw-maybe",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+            __undefined,
+            "application/octet-stream"
+        );
+    }
+
+    public getAliasedString(datasetRid: string): Promise<IAliasedString> {
+        return this.bridge.call<IAliasedString>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/string-aliased",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public uploadRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets/upload-raw",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+        );
+    }
+
+    public uploadAliasedRawData(input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/datasets/upload-raw-aliased",
+            input,
+            __undefined,
+            __undefined,
+            __undefined,
+            "application/octet-stream",
+        );
+    }
+
+    public getBranches(datasetRid: string): Promise<Array<string>> {
+        return this.bridge.call<Array<string>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @deprecated use getBranches instead
+     */
+    public getBranchesDeprecated(datasetRid: string): Promise<Array<string>> {
+        return this.bridge.call<Array<string>>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branchesDeprecated",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public resolveBranch(datasetRid: string, branch: string): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+
+                branch,
+            ],
+        );
+    }
+
+    public testParam(datasetRid: string): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/datasets/{datasetRid}/testParam",
+            __undefined,
+            __undefined,
+            __undefined,
+            [
+                datasetRid,
+            ],
+        );
+    }
+
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+        return this.bridge.call<number>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/test-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+        );
+    }
+
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/test-no-response-query-params",
+            query,
+            __undefined,
+            {
+                "different": something,
+
+                "implicit": implicit,
+
+                "setEnd": setEnd,
+
+                "optionalMiddle": optionalMiddle,
+
+                "optionalEnd": optionalEnd,
+            },
+        );
+    }
+
+    public testBoolean(): Promise<boolean> {
+        return this.bridge.call<boolean>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/boolean",
+        );
+    }
+
+    public testDouble(): Promise<number | "NaN"> {
+        return this.bridge.call<number | "NaN">(__emptyString, __emptyString,
+            "GET",
+            "/catalog/double",
+        );
+    }
+
+    public testInteger(): Promise<number> {
+        return this.bridge.call<number>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/integer",
+        );
+    }
+
+    public testPostOptional(maybeString?: string | null): Promise<string | null> {
+        return this.bridge.call<string | null>(__emptyString, __emptyString,
+            "POST",
+            "/catalog/optional",
+            maybeString,
+        );
+    }
+
+    public testOptionalIntegerAndDouble(maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+        return this.bridge.call<void>(__emptyString, __emptyString,
+            "GET",
+            "/catalog/optional-integer-double",
+            __undefined,
+            __undefined,
+            {
+                "maybeInteger": maybeInteger,
+
+                "maybeDouble": maybeDouble,
+            },
+        );
+    }
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-service/product-datasets/backingFileSystem.ts
@@ -1,0 +1,6 @@
+export interface IBackingFileSystem {
+    /** The name by which this file system is identified. */
+    'fileSystemId': string;
+    'baseUri': string;
+    'configuration': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-service/product-datasets/dataset.ts
@@ -1,0 +1,5 @@
+export interface IDataset {
+    'fileSystemId': string;
+    /** Uniquely identifies this dataset. */
+    'rid': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-service/product/aliasedString.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-service/product/aliasedString.ts
@@ -1,0 +1,4 @@
+export type IAliasedString = string & {
+    __conjure_type?: "AliasedString",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-service/product/createDatasetRequest.ts
@@ -1,0 +1,4 @@
+export interface ICreateDatasetRequest {
+    'fileSystemId': string;
+    'path': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/aliasAsMapKeyExample.ts
@@ -1,0 +1,17 @@
+import { IBearerTokenAliasExample } from "./bearerTokenAliasExample";
+import { IIntegerAliasExample } from "./integerAliasExample";
+import { IManyFieldExample } from "./manyFieldExample";
+import { IRidAliasExample } from "./ridAliasExample";
+import { ISafeLongAliasExample } from "./safeLongAliasExample";
+import { IStringAliasExample } from "./stringAliasExample";
+import { IUuidAliasExample } from "./uuidAliasExample";
+
+export interface IAliasAsMapKeyExample {
+    'strings': { [key: IStringAliasExample]: IManyFieldExample };
+    'rids': { [key: IRidAliasExample]: IManyFieldExample };
+    'bearertokens': { [key: IBearerTokenAliasExample]: IManyFieldExample };
+    'integers': { [key: IIntegerAliasExample]: IManyFieldExample };
+    'safelongs': { [key: ISafeLongAliasExample]: IManyFieldExample };
+    'datetimes': { [key: string]: IManyFieldExample };
+    'uuids': { [key: IUuidAliasExample]: IManyFieldExample };
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/anyExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyExample {
+    'any': any;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/anyMapExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyMapExample {
+    'items': { [key: string]: any };
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerAliasExample = string & {
+    __conjure_type?: "BearerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerTokenAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerTokenAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerTokenAliasExample = string & {
+    __conjure_type?: "BearerTokenAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/bearerTokenExample.ts
@@ -1,0 +1,3 @@
+export interface IBearerTokenExample {
+    'bearerTokenValue': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/booleanExample.ts
@@ -1,0 +1,3 @@
+export interface IBooleanExample {
+    'coin': boolean;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/covariantListExample.ts
@@ -1,0 +1,4 @@
+export interface ICovariantListExample {
+    'items': Array<any>;
+    'externalItems': Array<string>;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/covariantOptionalExample.ts
@@ -1,0 +1,3 @@
+export interface ICovariantOptionalExample {
+    'item'?: any | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/dateTimeExample.ts
@@ -1,0 +1,3 @@
+export interface IDateTimeExample {
+    'datetime': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedEnumExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedEnumExample.ts
@@ -1,0 +1,25 @@
+export namespace DeprecatedEnumExample {
+    export type ONE = "ONE";
+    /** @deprecated use ONE */
+    export type OLD_ONE = "OLD_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    export type OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    export type OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE";
+
+    export const ONE = "ONE" as "ONE";
+    export const OLD_ONE = "OLD_ONE" as "OLD_ONE";
+    export const OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE" as "OLD_DEPRECATED_ONE";
+    export const OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE" as "OLD_DOCUMENTED_ONE";
+}
+
+export type DeprecatedEnumExample = keyof typeof DeprecatedEnumExample;

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedFieldExample.ts
@@ -1,0 +1,18 @@
+export interface IDeprecatedFieldExample {
+    'one': string;
+    /** @deprecated use ONE */
+    'deprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    'documentedDeprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    'deprecatedWithinDocumentOne': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/deprecatedUnion.ts
@@ -1,0 +1,86 @@
+export interface IDeprecatedUnion_Good {
+    'good': string;
+    'type': "good";
+}
+
+/** @deprecated use good */
+export interface IDeprecatedUnion_NoGood {
+    'noGood': string;
+    'type': "noGood";
+}
+
+/**
+ * this is no good
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGoodDoc {
+    'noGoodDoc': string;
+    'type': "noGoodDoc";
+}
+
+function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
+    return (obj.type === "good");
+}
+
+function good(obj: string): IDeprecatedUnion_Good {
+    return {
+        good: obj,
+        type: "good",
+    };
+}
+
+function isNoGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGood {
+    return (obj.type === "noGood");
+}
+
+/** @deprecated use good */
+function noGood(obj: string): IDeprecatedUnion_NoGood {
+    return {
+        noGood: obj,
+        type: "noGood",
+    };
+}
+
+function isNoGoodDoc(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGoodDoc {
+    return (obj.type === "noGoodDoc");
+}
+
+/** @deprecated use good */
+function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
+    return {
+        noGoodDoc: obj,
+        type: "noGoodDoc",
+    };
+}
+
+export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
+
+export interface IDeprecatedUnionVisitor<T> {
+    'good': (obj: string) => T;
+    'noGood': (obj: string) => T;
+    'noGoodDoc': (obj: string) => T;
+    'unknown': (obj: IDeprecatedUnion) => T;
+}
+
+function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
+    if (isGood(obj)) {
+        return visitor.good(obj.good);
+    }
+    if (isNoGood(obj)) {
+        return visitor.noGood(obj.noGood);
+    }
+    if (isNoGoodDoc(obj)) {
+        return visitor.noGoodDoc(obj.noGoodDoc);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IDeprecatedUnion = {
+    isGood: isGood,
+    good: good,
+    isNoGood: isNoGood,
+    noGood: noGood,
+    isNoGoodDoc: isNoGoodDoc,
+    noGoodDoc: noGoodDoc,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/doubleAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/doubleAliasExample.ts
@@ -1,0 +1,4 @@
+export type IDoubleAliasExample = number | "NaN" & {
+    __conjure_type?: "DoubleAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/doubleExample.ts
@@ -1,0 +1,3 @@
+export interface IDoubleExample {
+    'doubleValue': number | "NaN";
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/emptyEnum.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/emptyEnum.ts
@@ -1,0 +1,3 @@
+export const EmptyEnum = {};
+
+export type EmptyEnum = void;

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/emptyObjectExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/emptyObjectExample.ts
@@ -1,0 +1,2 @@
+export interface IEmptyObjectExample {
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/enumExample.ts
@@ -1,0 +1,16 @@
+/**
+ * This enumerates the numbers 1:2 also 100.
+ *
+ */
+export namespace EnumExample {
+    export type ONE = "ONE";
+    export type TWO = "TWO";
+    /** Value of 100. */
+    export type ONE_HUNDRED = "ONE_HUNDRED";
+
+    export const ONE = "ONE" as "ONE";
+    export const TWO = "TWO" as "TWO";
+    export const ONE_HUNDRED = "ONE_HUNDRED" as "ONE_HUNDRED";
+}
+
+export type EnumExample = keyof typeof EnumExample;

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/enumFieldExample.ts
@@ -1,0 +1,5 @@
+import { EnumExample } from "./enumExample";
+
+export interface IEnumFieldExample {
+    'enum': EnumExample;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/externalLongExample.ts
@@ -1,0 +1,5 @@
+export interface IExternalLongExample {
+    'externalLong': number;
+    'optionalExternalLong'?: number | null;
+    'listExternalLong': Array<number>;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/integerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/integerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IIntegerAliasExample = number & {
+    __conjure_type?: "IntegerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/integerExample.ts
@@ -1,0 +1,3 @@
+export interface IIntegerExample {
+    'integer': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/listExample.ts
@@ -1,0 +1,5 @@
+export interface IListExample {
+    'items': Array<string>;
+    'primitiveItems': Array<number>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/manyFieldExample.ts
@@ -1,0 +1,20 @@
+import { IStringAliasExample } from "./stringAliasExample";
+
+export interface IManyFieldExample {
+    /** docs for string field */
+    'string': string;
+    /** docs for integer field */
+    'integer': number;
+    /** docs for doubleValue field */
+    'doubleValue': number | "NaN";
+    /** docs for optionalItem field */
+    'optionalItem'?: string | null;
+    /** docs for items field */
+    'items': Array<string>;
+    /** docs for set field */
+    'set': Array<string>;
+    /** docs for map field */
+    'map': { [key: string]: string };
+    /** docs for alias field */
+    'alias': IStringAliasExample;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/mapExample.ts
@@ -1,0 +1,3 @@
+export interface IMapExample {
+    'items': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/primitiveOptionalsExample.ts
@@ -1,0 +1,9 @@
+export interface IPrimitiveOptionalsExample {
+    'num'?: number | "NaN" | null;
+    'bool'?: boolean | null;
+    'integer'?: number | null;
+    'safelong'?: number | null;
+    'rid'?: string | null;
+    'bearertoken'?: string | null;
+    'uuid'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/reservedKeyExample.ts
@@ -1,0 +1,7 @@
+export interface IReservedKeyExample {
+    'package': string;
+    'interface': string;
+    'field-name-with-dashes': string;
+    'primitve-field-name-with-dashes': number;
+    'memoizedHashCode': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/ridAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/ridAliasExample.ts
@@ -1,0 +1,4 @@
+export type IRidAliasExample = string & {
+    __conjure_type?: "RidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/ridExample.ts
@@ -1,0 +1,3 @@
+export interface IRidExample {
+    'ridValue': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/safeLongAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/safeLongAliasExample.ts
@@ -1,0 +1,4 @@
+export type ISafeLongAliasExample = number & {
+    __conjure_type?: "SafeLongAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/safeLongExample.ts
@@ -1,0 +1,3 @@
+export interface ISafeLongExample {
+    'safeLongValue': number;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/setExample.ts
@@ -1,0 +1,4 @@
+export interface ISetExample {
+    'items': Array<string>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/simpleEnum.ts
@@ -1,0 +1,7 @@
+export namespace SimpleEnum {
+    export type VALUE = "VALUE";
+
+    export const VALUE = "VALUE" as "VALUE";
+}
+
+export type SimpleEnum = keyof typeof SimpleEnum;

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/singleUnion.ts
@@ -1,0 +1,35 @@
+export interface ISingleUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): ISingleUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+export type ISingleUnion = ISingleUnion_Foo;
+
+export interface ISingleUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'unknown': (obj: ISingleUnion) => T;
+}
+
+function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    return visitor.unknown(obj);
+}
+
+export const ISingleUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringAliasExample.ts
@@ -1,0 +1,4 @@
+export type IStringAliasExample = string & {
+    __conjure_type?: "StringAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringAliasOne.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringAliasOne.ts
@@ -1,0 +1,4 @@
+export type IStringAliasOne = string & {
+    __conjure_type?: "StringAliasOne",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/stringExample.ts
@@ -1,0 +1,3 @@
+export interface IStringExample {
+    'string': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/union.ts
@@ -1,0 +1,79 @@
+export interface IUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+export interface IUnion_Bar {
+    'bar': number;
+    'type': "bar";
+}
+
+export interface IUnion_Baz {
+    'baz': number;
+    'type': "baz";
+}
+
+function isFoo(obj: IUnion): obj is IUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): IUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+function isBar(obj: IUnion): obj is IUnion_Bar {
+    return (obj.type === "bar");
+}
+
+function bar(obj: number): IUnion_Bar {
+    return {
+        bar: obj,
+        type: "bar",
+    };
+}
+
+function isBaz(obj: IUnion): obj is IUnion_Baz {
+    return (obj.type === "baz");
+}
+
+function baz(obj: number): IUnion_Baz {
+    return {
+        baz: obj,
+        type: "baz",
+    };
+}
+
+export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
+
+export interface IUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'bar': (obj: number) => T;
+    'baz': (obj: number) => T;
+    'unknown': (obj: IUnion) => T;
+}
+
+function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    if (isBar(obj)) {
+        return visitor.bar(obj.bar);
+    }
+    if (isBaz(obj)) {
+        return visitor.baz(obj.baz);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    isBar: isBar,
+    bar: bar,
+    isBaz: isBaz,
+    baz: baz,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/unionTypeExample.ts
@@ -1,0 +1,171 @@
+import { IStringExample } from "./stringExample";
+
+/** Docs for when UnionTypeExample is of type StringExample. */
+export interface IUnionTypeExample_StringExample {
+    'stringExample': IStringExample;
+    'type': "stringExample";
+}
+
+export interface IUnionTypeExample_Set {
+    'set': Array<string>;
+    'type': "set";
+}
+
+export interface IUnionTypeExample_ThisFieldIsAnInteger {
+    'thisFieldIsAnInteger': number;
+    'type': "thisFieldIsAnInteger";
+}
+
+export interface IUnionTypeExample_AlsoAnInteger {
+    'alsoAnInteger': number;
+    'type': "alsoAnInteger";
+}
+
+export interface IUnionTypeExample_If {
+    'if': number;
+    'type': "if";
+}
+
+export interface IUnionTypeExample_New {
+    'new': number;
+    'type': "new";
+}
+
+export interface IUnionTypeExample_Interface {
+    'interface': number;
+    'type': "interface";
+}
+
+function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
+    return (obj.type === "stringExample");
+}
+
+function stringExample(obj: IStringExample): IUnionTypeExample_StringExample {
+    return {
+        stringExample: obj,
+        type: "stringExample",
+    };
+}
+
+function isSet(obj: IUnionTypeExample): obj is IUnionTypeExample_Set {
+    return (obj.type === "set");
+}
+
+function set(obj: Array<string>): IUnionTypeExample_Set {
+    return {
+        set: obj,
+        type: "set",
+    };
+}
+
+function isThisFieldIsAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_ThisFieldIsAnInteger {
+    return (obj.type === "thisFieldIsAnInteger");
+}
+
+function thisFieldIsAnInteger(obj: number): IUnionTypeExample_ThisFieldIsAnInteger {
+    return {
+        thisFieldIsAnInteger: obj,
+        type: "thisFieldIsAnInteger",
+    };
+}
+
+function isAlsoAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_AlsoAnInteger {
+    return (obj.type === "alsoAnInteger");
+}
+
+function alsoAnInteger(obj: number): IUnionTypeExample_AlsoAnInteger {
+    return {
+        alsoAnInteger: obj,
+        type: "alsoAnInteger",
+    };
+}
+
+function isIf(obj: IUnionTypeExample): obj is IUnionTypeExample_If {
+    return (obj.type === "if");
+}
+
+function if_(obj: number): IUnionTypeExample_If {
+    return {
+        if: obj,
+        type: "if",
+    };
+}
+
+function isNew(obj: IUnionTypeExample): obj is IUnionTypeExample_New {
+    return (obj.type === "new");
+}
+
+function new_(obj: number): IUnionTypeExample_New {
+    return {
+        new: obj,
+        type: "new",
+    };
+}
+
+function isInterface(obj: IUnionTypeExample): obj is IUnionTypeExample_Interface {
+    return (obj.type === "interface");
+}
+
+function interface_(obj: number): IUnionTypeExample_Interface {
+    return {
+        interface: obj,
+        type: "interface",
+    };
+}
+
+/** A type which can either be a StringExample, a set of strings, or an integer. */
+export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
+
+export interface IUnionTypeExampleVisitor<T> {
+    'stringExample': (obj: IStringExample) => T;
+    'set': (obj: Array<string>) => T;
+    'thisFieldIsAnInteger': (obj: number) => T;
+    'alsoAnInteger': (obj: number) => T;
+    'if': (obj: number) => T;
+    'new': (obj: number) => T;
+    'interface': (obj: number) => T;
+    'unknown': (obj: IUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
+    if (isStringExample(obj)) {
+        return visitor.stringExample(obj.stringExample);
+    }
+    if (isSet(obj)) {
+        return visitor.set(obj.set);
+    }
+    if (isThisFieldIsAnInteger(obj)) {
+        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+    }
+    if (isAlsoAnInteger(obj)) {
+        return visitor.alsoAnInteger(obj.alsoAnInteger);
+    }
+    if (isIf(obj)) {
+        return visitor.if(obj.if);
+    }
+    if (isNew(obj)) {
+        return visitor.new(obj.new);
+    }
+    if (isInterface(obj)) {
+        return visitor.interface(obj.interface);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnionTypeExample = {
+    isStringExample: isStringExample,
+    stringExample: stringExample,
+    isSet: isSet,
+    set: set,
+    isThisFieldIsAnInteger: isThisFieldIsAnInteger,
+    thisFieldIsAnInteger: thisFieldIsAnInteger,
+    isAlsoAnInteger: isAlsoAnInteger,
+    alsoAnInteger: alsoAnInteger,
+    isIf: isIf,
+    if_: if_,
+    isNew: isNew,
+    new_: new_,
+    isInterface: isInterface,
+    interface_: interface_,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/uuidAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/uuidAliasExample.ts
@@ -1,0 +1,4 @@
+export type IUuidAliasExample = string & {
+    __conjure_type?: "UuidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-slim/example-types/product/uuidExample.ts
@@ -1,0 +1,3 @@
+export interface IUuidExample {
+    'uuid': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-binary-types/binary/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    readonly 'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-binary-types/binary/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    readonly 'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
@@ -3,8 +3,307 @@ import { IDataset } from "../product-datasets/dataset";
 import { ICreateDatasetRequest } from "../product/createDatasetRequest";
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ readonly [key: string]: IBackingFileSystem }> {
+    return bridge(...[
+        "TestService",
+        "getFileSystems",
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[
+        "TestService",
+        "createDataset",
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[
+        "TestService",
+        "getDataset",
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getAliasedRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[
+        "TestService",
+        "maybeGetRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string> {
+    return bridge(...[
+        "TestService",
+        "getAliasedString",
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadRawData",
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadAliasedRawData",
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadonlyArray<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranches",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadonlyArray<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranchesDeprecated",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "resolveBranch",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testParam",
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testQueryParams",
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testNoResponseQueryParams",
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[
+        "TestService",
+        "testBoolean",
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[
+        "TestService",
+        "testDouble",
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testInteger",
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testPostOptional",
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testOptionalIntegerAndDouble",
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}
 
 /**
  * A Markdown description of the service.

--- a/src/commands/generate/__tests__/resources/services/optionalService.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalService.ts
@@ -1,7 +1,23 @@
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+export function OptionalService_foo(bridge: IHttpApiBridge['call'], header: string, name?: string | null): Promise<void> {
+    return bridge(...[
+        "OptionalService",
+        "foo",
+        "GET",
+        "/foo",
+        ,
+        {
+            "Header": header,
+        },
+        {
+            "Query": name,
+        },
+    ] as Parameters<typeof bridge>);
+}
 
 export interface IOptionalService {
     foo(header: string, name?: string | null): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -1,7 +1,24 @@
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+export function OutOfOrderPathService_foo(bridge: IHttpApiBridge['call'], param1: string, param2: string): Promise<void> {
+    return bridge(...[
+        "OutOfOrderPathService",
+        "foo",
+        "GET",
+        "/{param2}/{param1}",
+        ,
+        ,
+        ,
+        [
+            param2,
+
+            param1,
+        ],
+    ] as Parameters<typeof bridge>);
+}
 
 export interface IOutOfOrderPathService {
     foo(param1: string, param2: string): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -1,7 +1,26 @@
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+export function ParamTypeService_foo(bridge: IHttpApiBridge['call'], body: string, header: string, path: string, query: string): Promise<void> {
+    return bridge(...[
+        "ParamTypeService",
+        "foo",
+        "GET",
+        "/foo/{path}",
+        body,
+        {
+            "Header": header,
+        },
+        {
+            "Query": query,
+        },
+        [
+            path,
+        ],
+    ] as Parameters<typeof bridge>);
+}
 
 export interface IParamTypeService {
     foo(body: string, header: string, path: string, query: string): Promise<void>;

--- a/src/commands/generate/__tests__/resources/services/primitiveService.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveService.ts
@@ -1,7 +1,16 @@
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+export function PrimitiveService_getPrimitive(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[
+        "PrimitiveService",
+        "getPrimitive",
+        "GET",
+        "/getPrimitive",
+    ] as Parameters<typeof bridge>);
+}
 
 export interface IPrimitiveService {
     getPrimitive(): Promise<number>;

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
@@ -1,7 +1,20 @@
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+export function ServiceWithSafelongHeader_foo(bridge: IHttpApiBridge['call'], investigation: number): Promise<void> {
+    return bridge(...[
+        "ServiceWithSafelongHeader",
+        "foo",
+        "GET",
+        "/foo",
+        ,
+        {
+            "X-Investigation": investigation.toString(),
+        },
+    ] as Parameters<typeof bridge>);
+}
 
 export interface IServiceWithSafelongHeader {
     foo(investigation: number): Promise<void>;

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-binary-types/binary/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-binary-types/binary/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-binary-types/binary/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-binary-types/binary/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-service/another/testService.ts
@@ -1,0 +1,267 @@
+import { IBackingFileSystem } from "../product-datasets/backingFileSystem";
+import { IDataset } from "../product-datasets/dataset";
+import { IAliasedString } from "../product/aliasedString";
+import { ICreateDatasetRequest } from "../product/createDatasetRequest";
+import { IHttpApiBridge } from "conjure-client";
+
+/** Constant references that we expect to get minified and therefore reduce total code size */
+const __emptyString: string = "";
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ [key: string]: IBackingFileSystem }> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IAliasedString> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[__emptyString, __emptyString,
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[__emptyString, __emptyString,
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product-datasets/backingFileSystem.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product-datasets/backingFileSystem.ts
@@ -1,0 +1,6 @@
+export interface IBackingFileSystem {
+    /** The name by which this file system is identified. */
+    'fileSystemId': string;
+    'baseUri': string;
+    'configuration': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product-datasets/dataset.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product-datasets/dataset.ts
@@ -1,0 +1,5 @@
+export interface IDataset {
+    'fileSystemId': string;
+    /** Uniquely identifies this dataset. */
+    'rid': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product/aliasedString.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product/aliasedString.ts
@@ -1,0 +1,4 @@
+export type IAliasedString = string & {
+    __conjure_type?: "AliasedString",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product/createDatasetRequest.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-service/product/createDatasetRequest.ts
@@ -1,0 +1,4 @@
+export interface ICreateDatasetRequest {
+    'fileSystemId': string;
+    'path': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/aliasAsMapKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/aliasAsMapKeyExample.ts
@@ -1,0 +1,17 @@
+import { IBearerTokenAliasExample } from "./bearerTokenAliasExample";
+import { IIntegerAliasExample } from "./integerAliasExample";
+import { IManyFieldExample } from "./manyFieldExample";
+import { IRidAliasExample } from "./ridAliasExample";
+import { ISafeLongAliasExample } from "./safeLongAliasExample";
+import { IStringAliasExample } from "./stringAliasExample";
+import { IUuidAliasExample } from "./uuidAliasExample";
+
+export interface IAliasAsMapKeyExample {
+    'strings': { [key: IStringAliasExample]: IManyFieldExample };
+    'rids': { [key: IRidAliasExample]: IManyFieldExample };
+    'bearertokens': { [key: IBearerTokenAliasExample]: IManyFieldExample };
+    'integers': { [key: IIntegerAliasExample]: IManyFieldExample };
+    'safelongs': { [key: ISafeLongAliasExample]: IManyFieldExample };
+    'datetimes': { [key: string]: IManyFieldExample };
+    'uuids': { [key: IUuidAliasExample]: IManyFieldExample };
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/anyExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/anyExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyExample {
+    'any': any;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/anyMapExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/anyMapExample.ts
@@ -1,0 +1,3 @@
+export interface IAnyMapExample {
+    'items': { [key: string]: any };
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerAliasExample = string & {
+    __conjure_type?: "BearerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerTokenAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerTokenAliasExample.ts
@@ -1,0 +1,4 @@
+export type IBearerTokenAliasExample = string & {
+    __conjure_type?: "BearerTokenAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerTokenExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/bearerTokenExample.ts
@@ -1,0 +1,3 @@
+export interface IBearerTokenExample {
+    'bearerTokenValue': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/binaryExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/binaryExample.ts
@@ -1,0 +1,3 @@
+export interface IBinaryExample {
+    'binary': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/booleanExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/booleanExample.ts
@@ -1,0 +1,3 @@
+export interface IBooleanExample {
+    'coin': boolean;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/covariantListExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/covariantListExample.ts
@@ -1,0 +1,4 @@
+export interface ICovariantListExample {
+    'items': Array<any>;
+    'externalItems': Array<string>;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/covariantOptionalExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/covariantOptionalExample.ts
@@ -1,0 +1,3 @@
+export interface ICovariantOptionalExample {
+    'item'?: any | null;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/dateTimeExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/dateTimeExample.ts
@@ -1,0 +1,3 @@
+export interface IDateTimeExample {
+    'datetime': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedEnumExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedEnumExample.ts
@@ -1,0 +1,25 @@
+export namespace DeprecatedEnumExample {
+    export type ONE = "ONE";
+    /** @deprecated use ONE */
+    export type OLD_ONE = "OLD_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    export type OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE";
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    export type OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE";
+
+    export const ONE = "ONE" as "ONE";
+    export const OLD_ONE = "OLD_ONE" as "OLD_ONE";
+    export const OLD_DEPRECATED_ONE = "OLD_DEPRECATED_ONE" as "OLD_DEPRECATED_ONE";
+    export const OLD_DOCUMENTED_ONE = "OLD_DOCUMENTED_ONE" as "OLD_DOCUMENTED_ONE";
+}
+
+export type DeprecatedEnumExample = keyof typeof DeprecatedEnumExample;

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedFieldExample.ts
@@ -1,0 +1,18 @@
+export interface IDeprecatedFieldExample {
+    'one': string;
+    /** @deprecated use ONE */
+    'deprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated use ONE
+     */
+    'documentedDeprecatedOne': string;
+    /**
+     * You should no longer use this
+     *
+     * @deprecated should use ONE
+     *
+     */
+    'deprecatedWithinDocumentOne': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/deprecatedUnion.ts
@@ -1,0 +1,86 @@
+export interface IDeprecatedUnion_Good {
+    'good': string;
+    'type': "good";
+}
+
+/** @deprecated use good */
+export interface IDeprecatedUnion_NoGood {
+    'noGood': string;
+    'type': "noGood";
+}
+
+/**
+ * this is no good
+ * @deprecated use good
+ */
+export interface IDeprecatedUnion_NoGoodDoc {
+    'noGoodDoc': string;
+    'type': "noGoodDoc";
+}
+
+function isGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_Good {
+    return (obj.type === "good");
+}
+
+function good(obj: string): IDeprecatedUnion_Good {
+    return {
+        good: obj,
+        type: "good",
+    };
+}
+
+function isNoGood(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGood {
+    return (obj.type === "noGood");
+}
+
+/** @deprecated use good */
+function noGood(obj: string): IDeprecatedUnion_NoGood {
+    return {
+        noGood: obj,
+        type: "noGood",
+    };
+}
+
+function isNoGoodDoc(obj: IDeprecatedUnion): obj is IDeprecatedUnion_NoGoodDoc {
+    return (obj.type === "noGoodDoc");
+}
+
+/** @deprecated use good */
+function noGoodDoc(obj: string): IDeprecatedUnion_NoGoodDoc {
+    return {
+        noGoodDoc: obj,
+        type: "noGoodDoc",
+    };
+}
+
+export type IDeprecatedUnion = IDeprecatedUnion_Good | IDeprecatedUnion_NoGood | IDeprecatedUnion_NoGoodDoc;
+
+export interface IDeprecatedUnionVisitor<T> {
+    'good': (obj: string) => T;
+    'noGood': (obj: string) => T;
+    'noGoodDoc': (obj: string) => T;
+    'unknown': (obj: IDeprecatedUnion) => T;
+}
+
+function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
+    if (isGood(obj)) {
+        return visitor.good(obj.good);
+    }
+    if (isNoGood(obj)) {
+        return visitor.noGood(obj.noGood);
+    }
+    if (isNoGoodDoc(obj)) {
+        return visitor.noGoodDoc(obj.noGoodDoc);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IDeprecatedUnion = {
+    isGood: isGood,
+    good: good,
+    isNoGood: isNoGood,
+    noGood: noGood,
+    isNoGoodDoc: isNoGoodDoc,
+    noGoodDoc: noGoodDoc,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/doubleAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/doubleAliasExample.ts
@@ -1,0 +1,4 @@
+export type IDoubleAliasExample = number | "NaN" & {
+    __conjure_type?: "DoubleAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/doubleExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/doubleExample.ts
@@ -1,0 +1,3 @@
+export interface IDoubleExample {
+    'doubleValue': number | "NaN";
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/emptyEnum.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/emptyEnum.ts
@@ -1,0 +1,3 @@
+export const EmptyEnum = {};
+
+export type EmptyEnum = void;

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/emptyObjectExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/emptyObjectExample.ts
@@ -1,0 +1,2 @@
+export interface IEmptyObjectExample {
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/enumExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/enumExample.ts
@@ -1,0 +1,16 @@
+/**
+ * This enumerates the numbers 1:2 also 100.
+ *
+ */
+export namespace EnumExample {
+    export type ONE = "ONE";
+    export type TWO = "TWO";
+    /** Value of 100. */
+    export type ONE_HUNDRED = "ONE_HUNDRED";
+
+    export const ONE = "ONE" as "ONE";
+    export const TWO = "TWO" as "TWO";
+    export const ONE_HUNDRED = "ONE_HUNDRED" as "ONE_HUNDRED";
+}
+
+export type EnumExample = keyof typeof EnumExample;

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/enumFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/enumFieldExample.ts
@@ -1,0 +1,5 @@
+import { EnumExample } from "./enumExample";
+
+export interface IEnumFieldExample {
+    'enum': EnumExample;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/externalLongExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/externalLongExample.ts
@@ -1,0 +1,5 @@
+export interface IExternalLongExample {
+    'externalLong': number;
+    'optionalExternalLong'?: number | null;
+    'listExternalLong': Array<number>;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/integerAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/integerAliasExample.ts
@@ -1,0 +1,4 @@
+export type IIntegerAliasExample = number & {
+    __conjure_type?: "IntegerAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/integerExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/integerExample.ts
@@ -1,0 +1,3 @@
+export interface IIntegerExample {
+    'integer': number;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/listExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/listExample.ts
@@ -1,0 +1,5 @@
+export interface IListExample {
+    'items': Array<string>;
+    'primitiveItems': Array<number>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/manyFieldExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/manyFieldExample.ts
@@ -1,0 +1,20 @@
+import { IStringAliasExample } from "./stringAliasExample";
+
+export interface IManyFieldExample {
+    /** docs for string field */
+    'string': string;
+    /** docs for integer field */
+    'integer': number;
+    /** docs for doubleValue field */
+    'doubleValue': number | "NaN";
+    /** docs for optionalItem field */
+    'optionalItem'?: string | null;
+    /** docs for items field */
+    'items': Array<string>;
+    /** docs for set field */
+    'set': Array<string>;
+    /** docs for map field */
+    'map': { [key: string]: string };
+    /** docs for alias field */
+    'alias': IStringAliasExample;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/mapExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/mapExample.ts
@@ -1,0 +1,3 @@
+export interface IMapExample {
+    'items': { [key: string]: string };
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/optionalExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/optionalExample.ts
@@ -1,0 +1,3 @@
+export interface IOptionalExample {
+    'item'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/primitiveOptionalsExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/primitiveOptionalsExample.ts
@@ -1,0 +1,9 @@
+export interface IPrimitiveOptionalsExample {
+    'num'?: number | "NaN" | null;
+    'bool'?: boolean | null;
+    'integer'?: number | null;
+    'safelong'?: number | null;
+    'rid'?: string | null;
+    'bearertoken'?: string | null;
+    'uuid'?: string | null;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/reservedKeyExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/reservedKeyExample.ts
@@ -1,0 +1,7 @@
+export interface IReservedKeyExample {
+    'package': string;
+    'interface': string;
+    'field-name-with-dashes': string;
+    'primitve-field-name-with-dashes': number;
+    'memoizedHashCode': number;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/ridAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/ridAliasExample.ts
@@ -1,0 +1,4 @@
+export type IRidAliasExample = string & {
+    __conjure_type?: "RidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/ridExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/ridExample.ts
@@ -1,0 +1,3 @@
+export interface IRidExample {
+    'ridValue': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/safeLongAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/safeLongAliasExample.ts
@@ -1,0 +1,4 @@
+export type ISafeLongAliasExample = number & {
+    __conjure_type?: "SafeLongAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/safeLongExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/safeLongExample.ts
@@ -1,0 +1,3 @@
+export interface ISafeLongExample {
+    'safeLongValue': number;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/setExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/setExample.ts
@@ -1,0 +1,4 @@
+export interface ISetExample {
+    'items': Array<string>;
+    'doubleItems': Array<number | "NaN">;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/simpleEnum.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/simpleEnum.ts
@@ -1,0 +1,7 @@
+export namespace SimpleEnum {
+    export type VALUE = "VALUE";
+
+    export const VALUE = "VALUE" as "VALUE";
+}
+
+export type SimpleEnum = keyof typeof SimpleEnum;

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/singleUnion.ts
@@ -1,0 +1,35 @@
+export interface ISingleUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+function isFoo(obj: ISingleUnion): obj is ISingleUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): ISingleUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+export type ISingleUnion = ISingleUnion_Foo;
+
+export interface ISingleUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'unknown': (obj: ISingleUnion) => T;
+}
+
+function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    return visitor.unknown(obj);
+}
+
+export const ISingleUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringAliasExample.ts
@@ -1,0 +1,4 @@
+export type IStringAliasExample = string & {
+    __conjure_type?: "StringAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringAliasOne.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringAliasOne.ts
@@ -1,0 +1,4 @@
+export type IStringAliasOne = string & {
+    __conjure_type?: "StringAliasOne",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/stringExample.ts
@@ -1,0 +1,3 @@
+export interface IStringExample {
+    'string': string;
+}

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/union.ts
@@ -1,0 +1,79 @@
+export interface IUnion_Foo {
+    'foo': string;
+    'type': "foo";
+}
+
+export interface IUnion_Bar {
+    'bar': number;
+    'type': "bar";
+}
+
+export interface IUnion_Baz {
+    'baz': number;
+    'type': "baz";
+}
+
+function isFoo(obj: IUnion): obj is IUnion_Foo {
+    return (obj.type === "foo");
+}
+
+function foo(obj: string): IUnion_Foo {
+    return {
+        foo: obj,
+        type: "foo",
+    };
+}
+
+function isBar(obj: IUnion): obj is IUnion_Bar {
+    return (obj.type === "bar");
+}
+
+function bar(obj: number): IUnion_Bar {
+    return {
+        bar: obj,
+        type: "bar",
+    };
+}
+
+function isBaz(obj: IUnion): obj is IUnion_Baz {
+    return (obj.type === "baz");
+}
+
+function baz(obj: number): IUnion_Baz {
+    return {
+        baz: obj,
+        type: "baz",
+    };
+}
+
+export type IUnion = IUnion_Foo | IUnion_Bar | IUnion_Baz;
+
+export interface IUnionVisitor<T> {
+    'foo': (obj: string) => T;
+    'bar': (obj: number) => T;
+    'baz': (obj: number) => T;
+    'unknown': (obj: IUnion) => T;
+}
+
+function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
+    if (isFoo(obj)) {
+        return visitor.foo(obj.foo);
+    }
+    if (isBar(obj)) {
+        return visitor.bar(obj.bar);
+    }
+    if (isBaz(obj)) {
+        return visitor.baz(obj.baz);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnion = {
+    isFoo: isFoo,
+    foo: foo,
+    isBar: isBar,
+    bar: bar,
+    isBaz: isBaz,
+    baz: baz,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/unionTypeExample.ts
@@ -1,0 +1,171 @@
+import { IStringExample } from "./stringExample";
+
+/** Docs for when UnionTypeExample is of type StringExample. */
+export interface IUnionTypeExample_StringExample {
+    'stringExample': IStringExample;
+    'type': "stringExample";
+}
+
+export interface IUnionTypeExample_Set {
+    'set': Array<string>;
+    'type': "set";
+}
+
+export interface IUnionTypeExample_ThisFieldIsAnInteger {
+    'thisFieldIsAnInteger': number;
+    'type': "thisFieldIsAnInteger";
+}
+
+export interface IUnionTypeExample_AlsoAnInteger {
+    'alsoAnInteger': number;
+    'type': "alsoAnInteger";
+}
+
+export interface IUnionTypeExample_If {
+    'if': number;
+    'type': "if";
+}
+
+export interface IUnionTypeExample_New {
+    'new': number;
+    'type': "new";
+}
+
+export interface IUnionTypeExample_Interface {
+    'interface': number;
+    'type': "interface";
+}
+
+function isStringExample(obj: IUnionTypeExample): obj is IUnionTypeExample_StringExample {
+    return (obj.type === "stringExample");
+}
+
+function stringExample(obj: IStringExample): IUnionTypeExample_StringExample {
+    return {
+        stringExample: obj,
+        type: "stringExample",
+    };
+}
+
+function isSet(obj: IUnionTypeExample): obj is IUnionTypeExample_Set {
+    return (obj.type === "set");
+}
+
+function set(obj: Array<string>): IUnionTypeExample_Set {
+    return {
+        set: obj,
+        type: "set",
+    };
+}
+
+function isThisFieldIsAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_ThisFieldIsAnInteger {
+    return (obj.type === "thisFieldIsAnInteger");
+}
+
+function thisFieldIsAnInteger(obj: number): IUnionTypeExample_ThisFieldIsAnInteger {
+    return {
+        thisFieldIsAnInteger: obj,
+        type: "thisFieldIsAnInteger",
+    };
+}
+
+function isAlsoAnInteger(obj: IUnionTypeExample): obj is IUnionTypeExample_AlsoAnInteger {
+    return (obj.type === "alsoAnInteger");
+}
+
+function alsoAnInteger(obj: number): IUnionTypeExample_AlsoAnInteger {
+    return {
+        alsoAnInteger: obj,
+        type: "alsoAnInteger",
+    };
+}
+
+function isIf(obj: IUnionTypeExample): obj is IUnionTypeExample_If {
+    return (obj.type === "if");
+}
+
+function if_(obj: number): IUnionTypeExample_If {
+    return {
+        if: obj,
+        type: "if",
+    };
+}
+
+function isNew(obj: IUnionTypeExample): obj is IUnionTypeExample_New {
+    return (obj.type === "new");
+}
+
+function new_(obj: number): IUnionTypeExample_New {
+    return {
+        new: obj,
+        type: "new",
+    };
+}
+
+function isInterface(obj: IUnionTypeExample): obj is IUnionTypeExample_Interface {
+    return (obj.type === "interface");
+}
+
+function interface_(obj: number): IUnionTypeExample_Interface {
+    return {
+        interface: obj,
+        type: "interface",
+    };
+}
+
+/** A type which can either be a StringExample, a set of strings, or an integer. */
+export type IUnionTypeExample = IUnionTypeExample_StringExample | IUnionTypeExample_Set | IUnionTypeExample_ThisFieldIsAnInteger | IUnionTypeExample_AlsoAnInteger | IUnionTypeExample_If | IUnionTypeExample_New | IUnionTypeExample_Interface;
+
+export interface IUnionTypeExampleVisitor<T> {
+    'stringExample': (obj: IStringExample) => T;
+    'set': (obj: Array<string>) => T;
+    'thisFieldIsAnInteger': (obj: number) => T;
+    'alsoAnInteger': (obj: number) => T;
+    'if': (obj: number) => T;
+    'new': (obj: number) => T;
+    'interface': (obj: number) => T;
+    'unknown': (obj: IUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
+    if (isStringExample(obj)) {
+        return visitor.stringExample(obj.stringExample);
+    }
+    if (isSet(obj)) {
+        return visitor.set(obj.set);
+    }
+    if (isThisFieldIsAnInteger(obj)) {
+        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+    }
+    if (isAlsoAnInteger(obj)) {
+        return visitor.alsoAnInteger(obj.alsoAnInteger);
+    }
+    if (isIf(obj)) {
+        return visitor.if(obj.if);
+    }
+    if (isNew(obj)) {
+        return visitor.new(obj.new);
+    }
+    if (isInterface(obj)) {
+        return visitor.interface(obj.interface);
+    }
+    return visitor.unknown(obj);
+}
+
+export const IUnionTypeExample = {
+    isStringExample: isStringExample,
+    stringExample: stringExample,
+    isSet: isSet,
+    set: set,
+    isThisFieldIsAnInteger: isThisFieldIsAnInteger,
+    thisFieldIsAnInteger: thisFieldIsAnInteger,
+    isAlsoAnInteger: isAlsoAnInteger,
+    alsoAnInteger: alsoAnInteger,
+    isIf: isIf,
+    if_: if_,
+    isNew: isNew,
+    new_: new_,
+    isInterface: isInterface,
+    interface_: interface_,
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/uuidAliasExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/uuidAliasExample.ts
@@ -1,0 +1,4 @@
+export type IUuidAliasExample = string & {
+    __conjure_type?: "UuidAliasExample",
+    __conjure_package?: "com.palantir.product",
+};

--- a/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/uuidExample.ts
+++ b/src/commands/generate/__tests__/resources/slim-no-classes/example-types/product/uuidExample.ts
@@ -1,0 +1,3 @@
+export interface IUuidExample {
+    'uuid': string;
+}

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -3,8 +3,307 @@ import { IDataset } from "../product-datasets/dataset";
 import { ICreateDatasetRequest } from "../product/createDatasetRequest";
 import { IHttpApiBridge } from "conjure-client";
 
-/** Constant reference to `undefined` that we expect to get minified and therefore reduce total code size */
+/** Constant references that we expect to get minified and therefore reduce total code size */
 const __undefined: undefined = undefined;
+
+/**
+ * Returns a mapping from file system id to backing file system configuration.
+ *
+ */
+export function TestService_getFileSystems(bridge: IHttpApiBridge['call']): Promise<{ [key: string]: IBackingFileSystem }> {
+    return bridge(...[
+        "TestService",
+        "getFileSystems",
+        "GET",
+        "/catalog/fileSystems",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_createDataset(bridge: IHttpApiBridge['call'], request: ICreateDatasetRequest, testHeaderArg: string): Promise<IDataset> {
+    return bridge(...[
+        "TestService",
+        "createDataset",
+        "POST",
+        "/catalog/datasets",
+        request,
+        {
+            "Test-Header": testHeaderArg,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getDataset(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<IDataset | null> {
+    return bridge(...[
+        "TestService",
+        "getDataset",
+        "GET",
+        "/catalog/datasets/{datasetRid}",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array>> {
+    return bridge(...[
+        "TestService",
+        "getAliasedRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_maybeGetRawData(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<ReadableStream<Uint8Array> | null> {
+    return bridge(...[
+        "TestService",
+        "maybeGetRawData",
+        "GET",
+        "/catalog/datasets/{datasetRid}/raw-maybe",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+        ,
+        "application/octet-stream"
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getAliasedString(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string> {
+    return bridge(...[
+        "TestService",
+        "getAliasedString",
+        "GET",
+        "/catalog/datasets/{datasetRid}/string-aliased",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadRawData",
+        "POST",
+        "/catalog/datasets/upload-raw",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_uploadAliasedRawData(bridge: IHttpApiBridge['call'], input: ReadableStream<Uint8Array> | BufferSource | Blob): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "uploadAliasedRawData",
+        "POST",
+        "/catalog/datasets/upload-raw-aliased",
+        input,
+        ,
+        ,
+        ,
+        "application/octet-stream",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_getBranches(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranches",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+/**
+ * Gets all branches of this dataset.
+ *
+ * @deprecated use getBranches instead
+ */
+export function TestService_getBranchesDeprecated(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<Array<string>> {
+    return bridge(...[
+        "TestService",
+        "getBranchesDeprecated",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_resolveBranch(bridge: IHttpApiBridge['call'], datasetRid: string, branch: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "resolveBranch",
+        "GET",
+        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+
+            branch,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testParam(bridge: IHttpApiBridge['call'], datasetRid: string): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testParam",
+        "GET",
+        "/catalog/datasets/{datasetRid}/testParam",
+        ,
+        ,
+        ,
+        [
+            datasetRid,
+        ],
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testQueryParams",
+        "POST",
+        "/catalog/test-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testNoResponseQueryParams(bridge: IHttpApiBridge['call'], query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testNoResponseQueryParams",
+        "POST",
+        "/catalog/test-no-response-query-params",
+        query,
+        ,
+        {
+            "different": something,
+
+            "implicit": implicit,
+
+            "setEnd": setEnd,
+
+            "optionalMiddle": optionalMiddle,
+
+            "optionalEnd": optionalEnd,
+        },
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testBoolean(bridge: IHttpApiBridge['call']): Promise<boolean> {
+    return bridge(...[
+        "TestService",
+        "testBoolean",
+        "GET",
+        "/catalog/boolean",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testDouble(bridge: IHttpApiBridge['call']): Promise<number | "NaN"> {
+    return bridge(...[
+        "TestService",
+        "testDouble",
+        "GET",
+        "/catalog/double",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testInteger(bridge: IHttpApiBridge['call']): Promise<number> {
+    return bridge(...[
+        "TestService",
+        "testInteger",
+        "GET",
+        "/catalog/integer",
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testPostOptional(bridge: IHttpApiBridge['call'], maybeString?: string | null): Promise<string | null> {
+    return bridge(...[
+        "TestService",
+        "testPostOptional",
+        "POST",
+        "/catalog/optional",
+        maybeString,
+    ] as Parameters<typeof bridge>);
+}
+
+export function TestService_testOptionalIntegerAndDouble(bridge: IHttpApiBridge['call'], maybeInteger?: number | null, maybeDouble?: number | "NaN" | null): Promise<void> {
+    return bridge(...[
+        "TestService",
+        "testOptionalIntegerAndDouble",
+        "GET",
+        "/catalog/optional-integer-double",
+        ,
+        ,
+        {
+            "maybeInteger": maybeInteger,
+
+            "maybeDouble": maybeDouble,
+        },
+    ] as Parameters<typeof bridge>);
+}
 
 /**
  * A Markdown description of the service.

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -63,6 +63,12 @@ export interface IGenerateCommandArgs {
      * Generated interfaces have readonly properties and collections
      */
     readonlyInterfaces?: boolean;
+
+    omitServiceMetadata?: boolean;
+
+    omitUnnecessaryArgs?: boolean;
+    
+    omitServiceClasses?: boolean;
 }
 
 interface ICleanedGenerateCommandArgs {
@@ -77,6 +83,10 @@ export interface ITsConfig {
         [option: string]: any;
     };
 }
+
+const omitUnnecessaryArgsDefault = false;
+const omitServiceMetadataDefault = false;
+const omitServiceClassesDefault = false;
 
 export class GenerateCommand implements CommandModule {
     public aliases = [];
@@ -128,6 +138,22 @@ export class GenerateCommand implements CommandModule {
                 describe: "Path to a file containing a list of product dependencies",
                 type: "string",
             })
+            .option("omitUnnecessaryArgs", {
+                default: omitUnnecessaryArgsDefault,
+                describe:
+                    "If true, generated service classes omit trailing 'undefined's. Does not apply to pure service functions.",
+                type: "boolean",
+            })
+            .option("omitServiceMetadata", {
+                default: omitServiceMetadataDefault,
+                describe: "Passes undefined to the serviceName, endpointName arguments of the bridge",
+                type: "boolean",
+            })
+            .option("omitServiceClasses", {
+                default: omitServiceClassesDefault,
+                describe: "Prevents generation of service classes and interfaces.",
+                type: "boolean",
+            })
             .demand(2);
     }
 
@@ -138,6 +164,9 @@ export class GenerateCommand implements CommandModule {
         const generatePromise = generate(conjureDefinition, output, {
             flavorizedAliases: args.flavorizedAliases ?? false,
             readonlyInterfaces: args.readonlyInterfaces ?? false,
+            omitServiceMetadata: args.omitServiceMetadata ?? omitServiceMetadataDefault,
+            omitUnnecessaryArgs: args.omitUnnecessaryArgs ?? omitUnnecessaryArgsDefault,
+            omitServiceClasses: args.omitServiceClasses ?? omitServiceClassesDefault,
         });
         if (rawSource) {
             return generatePromise;

--- a/src/commands/generate/generateCommand.ts
+++ b/src/commands/generate/generateCommand.ts
@@ -67,7 +67,7 @@ export interface IGenerateCommandArgs {
     omitServiceMetadata?: boolean;
 
     omitUnnecessaryArgs?: boolean;
-    
+
     omitServiceClasses?: boolean;
 }
 

--- a/src/commands/generate/typeGenerationFlags.ts
+++ b/src/commands/generate/typeGenerationFlags.ts
@@ -28,4 +28,10 @@ export interface ITypeGenerationFlags {
      * Generated interfaces have readonly properties and use ReadonlyArray instead of Array.
      */
     readonly readonlyInterfaces: boolean;
+
+    readonly omitServiceMetadata: boolean;
+
+    readonly omitUnnecessaryArgs: boolean;
+
+    readonly omitServiceClasses: boolean;
 }


### PR DESCRIPTION
Note: This PR is broken into two commits: one for the actual changes and one for a ton of fixture changes. You will likely want to review them separately. The fixture changes will mostly just require skimming.

This change causes all services to generate functions of the format `ServiceName_endpointMethodName` that take signature of the `call` method of the bridge AND the remaining args as their `ServiceName['endpointMethodName']` counterparts do.

These new functions also leverage a tuple spread for better minification.

This PR further adds command line flags to the generator:
* `--omitServiceMetadata` : Instead of generating `"ServiceName", "EndpointName"` as the first to arguments to all bridge calls, this flag will cause empty strings to be passed instead.
* `--omitUnnecessaryArgs` : Cause the same size reduction for service class methods that functions get.
* `--omitServiceClasses` : Skip generating service classes and interfaces