### PR TITLE
Generate JSDoc for declared thrown errors

### DIFF
--- a/changelog/@unreleased/changelog/5.2.0/pr-294.v2.yml
+++ b/changelog/@unreleased/changelog/5.2.0/pr-294.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Generate JSDoc for declared thrown errors
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/294

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "commander": "^2.19.0",
-    "conjure-api": "^4.14.1",
+    "conjure-api": "^4.50.0",
     "conjure-client": "^2.4.1",
     "fs-extra": "^10.1.0",
     "lodash": "^4.17.11",

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -53,6 +53,7 @@ describe("serviceGenerator", () => {
                         markers: [],
                         returns: { primitive: PrimitiveType.INTEGER, type: "primitive" },
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "PrimitiveService", package: "com.palantir.services" },
@@ -83,6 +84,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/foo",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "ServiceWithSafelongHeader", package: "com.palantir.services" },
@@ -105,6 +107,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/bar",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -132,6 +135,7 @@ describe("serviceGenerator", () => {
                         markers: [],
                         returns: { primitive: PrimitiveType.BINARY, type: "primitive" },
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -166,6 +170,7 @@ describe("serviceGenerator", () => {
                         markers: [],
                         returns: { primitive: PrimitiveType.BINARY, type: "primitive" },
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -203,6 +208,7 @@ describe("serviceGenerator", () => {
                         markers: [],
                         returns: foreignObject.reference,
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: {
@@ -273,6 +279,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/foo/{path}",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "ParamTypeService", package: "com.palantir.services" },
@@ -316,6 +323,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/{param2}/{param1}",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "OutOfOrderPathService", package: "com.palantir.services" },
@@ -350,6 +358,7 @@ describe("serviceGenerator", () => {
                         httpPath: "/foo",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -396,6 +405,7 @@ describe("serviceGenerator", () => {
                             httpPath: "/foo",
                             markers: [],
                             tags: [],
+                            errors: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -430,6 +440,7 @@ describe("serviceGenerator", () => {
                             httpPath: "/foo",
                             markers: [],
                             tags: [],
+                            errors: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -464,6 +475,7 @@ describe("serviceGenerator", () => {
                             httpPath: "/foo",
                             markers: [],
                             tags: [],
+                            errors: [],
                         },
                     ],
                     serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -490,6 +502,12 @@ describe("serviceGenerator", () => {
                         httpPath: "/foo",
                         markers: [],
                         tags: [],
+                        errors: [
+                            {
+                                error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
+                                docs: "MyError documentation",
+                            },
+                        ],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -503,7 +521,10 @@ describe("serviceGenerator", () => {
         expect(contents).toContain(
             `/** service level docs */
 export interface IMyService {
-    /** endpoint level docs */
+    /**
+     * endpoint level docs
+     * @throws {MyError} MyError documentation
+     */
     foo(): Promise<void>;
 }
 `,
@@ -527,6 +548,12 @@ export interface IMyService {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        errors: [
+                            {
+                                error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
+                                docs: "MyError documentation",
+                            },
+                        ],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -540,7 +567,10 @@ export interface IMyService {
         expect(contents).toContain(
             `
 export interface IMyService {
-    /** @incubating */
+    /**
+     * @incubating
+     * @throws {MyError} MyError documentation
+     */
     foo(): Promise<void>;
 }
 `,
@@ -559,6 +589,7 @@ export interface IMyService {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
@@ -612,6 +643,7 @@ export interface IMyService {
                         httpPath: "/foo",
                         markers: [],
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: { name: "OptionalService", package: "com.palantir.services" },

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -524,8 +524,8 @@ export interface IMyService {
 
         expect(contents).not.toContain(
             `
-        /** endpoint level docs */
-        foo(): Promise<void> {`,
+            /** endpoint level docs */
+            foo(): Promise<void> {`,
         );
     });
 

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -489,7 +489,7 @@ describe("serviceGenerator", () => {
         }
     });
 
-    it("emits service interfaces with docs", async () => {
+    it("emits service interfaces with error and incubating docs", async () => {
         await generateService(
             {
                 docs: "service level docs",
@@ -570,21 +570,26 @@ export interface IMyService {
         );
     });
 
-    it("emits endpoint with incubating and error doc", async () => {
+    it("emits endpoint with error docs", async () => {
         await generateService(
             {
                 endpoints: [
                     {
+                        docs: "endpoint level docs",
                         args: [],
-                        tags: ["incubating"],
+                        tags: [],
                         endpointName: "foo",
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
                         errors: [
                             {
-                                error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
-                                docs: "MyError documentation",
+                                error: { name: "MyError1", namespace: "MyNamespace", package: "com.palantir.services" },
+                                docs: "MyError1 documentation",
+                            },
+                            {
+                                error: { name: "MyError2", namespace: "MyNamespace", package: "com.palantir.services" },
+                                docs: "MyError2 documentation",
                             },
                         ],
                     },
@@ -601,8 +606,9 @@ export interface IMyService {
             `
 export interface IMyService {
     /**
-     * @incubating
-     * @throws {MyError} MyError documentation
+     * endpoint level docs
+     * @throws {MyError1} MyError1 documentation
+     * @throws {MyError2} MyError2 documentation
      */
     foo(): Promise<void>;
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -516,8 +516,8 @@ describe("serviceGenerator", () => {
         expect(contents).toContain(
             `/** service level docs */
 export interface IMyService {
-/** endpoint level docs */
-foo(): Promise<void>;
+    /** endpoint level docs */
+    foo(): Promise<void>;
 }
 `,
         );
@@ -529,56 +529,7 @@ foo(): Promise<void>;
         );
     });
 
-    it("emits service interfaces with error, incubating, and docs", async () => {
-        await generateService(
-            {
-                docs: "service level docs",
-                endpoints: [
-                    {
-                        args: [],
-                        docs: "endpoint level docs",
-                        endpointName: "foo",
-                        httpMethod: HttpMethod.GET,
-                        httpPath: "/foo",
-                        markers: [],
-                        tags: ["incubating"],
-                        errors: [
-                            {
-                                error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
-                                docs: "MyError documentation",
-                            },
-                        ],
-                    },
-                ],
-                serviceName: { name: "MyService", package: "com.palantir.services" },
-            },
-            new Map(),
-            simpleAst,
-            DEFAULT_TYPE_GENERATION_FLAGS,
-        );
-        const outFile = path.join(outDir, "services/myService.ts");
-        const contents = fs.readFileSync(outFile, "utf8");
-        expect(contents).toContain(
-            `/** service level docs */
-export interface IMyService {
-    /**
-     * endpoint level docs
-     * @incubating
-     * @throws {MyError} MyError documentation
-     */
-    foo(): Promise<void>;
-}
-`,
-        );
-
-        expect(contents).not.toContain(
-            `
-            /** endpoint level docs */
-            foo(): Promise<void> {`,
-        );
-    });
-
-    it("emits endpoint with incubating", async () => {
+    it("emits endpoint with incubating docs", async () => {
         await generateService(
             {
                 endpoints: [
@@ -654,6 +605,55 @@ export interface IMyService {
     foo(): Promise<void>;
 }
 `,
+        );
+    });
+
+    it("emits service interfaces with error incubating docs", async () => {
+        await generateService(
+            {
+                docs: "service level docs",
+                endpoints: [
+                    {
+                        args: [],
+                        docs: "endpoint level docs",
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/foo",
+                        markers: [],
+                        tags: ["incubating"],
+                        errors: [
+                            {
+                                error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
+                                docs: "MyError documentation",
+                            },
+                        ],
+                    },
+                ],
+                serviceName: { name: "MyService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+            DEFAULT_TYPE_GENERATION_FLAGS,
+        );
+        const outFile = path.join(outDir, "services/myService.ts");
+        const contents = fs.readFileSync(outFile, "utf8");
+        expect(contents).toContain(
+            `/** service level docs */
+export interface IMyService {
+    /**
+     * endpoint level docs
+     * @incubating
+     * @throws {MyError} MyError documentation
+     */
+    foo(): Promise<void>;
+}
+`,
+        );
+
+        expect(contents).not.toContain(
+            `
+          /** endpoint level docs */
+          foo(): Promise<void> {`,
         );
     });
 

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -501,7 +501,7 @@ describe("serviceGenerator", () => {
                         httpMethod: HttpMethod.GET,
                         httpPath: "/foo",
                         markers: [],
-                        tags: [],
+                        tags: ["incubating"],
                         errors: [
                             {
                                 error: { name: "MyError", namespace: "MyNamespace", package: "com.palantir.services" },
@@ -523,6 +523,7 @@ describe("serviceGenerator", () => {
 export interface IMyService {
     /**
      * endpoint level docs
+     * @incubating
      * @throws {MyError} MyError documentation
      */
     foo(): Promise<void>;
@@ -538,6 +539,38 @@ export interface IMyService {
     });
 
     it("emits endpoint with incubating doc", async () => {
+        await generateService(
+            {
+                endpoints: [
+                    {
+                        args: [],
+                        tags: ["incubating"],
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/foo",
+                        markers: [],
+                        errors: [],
+                    },
+                ],
+                serviceName: { name: "MyService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+            DEFAULT_TYPE_GENERATION_FLAGS,
+        );
+        const outFile = path.join(outDir, "services/myService.ts");
+        const contents = fs.readFileSync(outFile, "utf8");
+        expect(contents).toContain(
+            `
+export interface IMyService {
+    /** @incubating */
+    foo(): Promise<void>;
+}
+`,
+        );
+    });
+
+    it("emits endpoint with incubating and error doc", async () => {
         await generateService(
             {
                 endpoints: [

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -489,7 +489,47 @@ describe("serviceGenerator", () => {
         }
     });
 
-    it("emits service interfaces with error and incubating docs", async () => {
+    it("emits service interfaces with docs", async () => {
+        await generateService(
+            {
+                docs: "service level docs",
+                endpoints: [
+                    {
+                        args: [],
+                        docs: "endpoint level docs",
+                        endpointName: "foo",
+                        httpMethod: HttpMethod.GET,
+                        httpPath: "/foo",
+                        markers: [],
+                        tags: [],
+                        errors: [],
+                    },
+                ],
+                serviceName: { name: "MyService", package: "com.palantir.services" },
+            },
+            new Map(),
+            simpleAst,
+            DEFAULT_TYPE_GENERATION_FLAGS,
+        );
+        const outFile = path.join(outDir, "services/myService.ts");
+        const contents = fs.readFileSync(outFile, "utf8");
+        expect(contents).toContain(
+            `/** service level docs */
+export interface IMyService {
+/** endpoint level docs */
+foo(): Promise<void>;
+}
+`,
+        );
+
+        expect(contents).not.toContain(
+            `
+        /** endpoint level docs */
+        foo(): Promise<void> {`,
+        );
+    });
+
+    it("emits service interfaces with error, incubating, and docs", async () => {
         await generateService(
             {
                 docs: "service level docs",
@@ -538,7 +578,7 @@ export interface IMyService {
         );
     });
 
-    it("emits endpoint with incubating doc", async () => {
+    it("emits endpoint with incubating", async () => {
         await generateService(
             {
                 endpoints: [
@@ -573,6 +613,7 @@ export interface IMyService {
     it("emits endpoint with error docs", async () => {
         await generateService(
             {
+                docs: "service level docs",
                 endpoints: [
                     {
                         docs: "endpoint level docs",
@@ -603,7 +644,7 @@ export interface IMyService {
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
         expect(contents).toContain(
-            `
+            `/** service level docs */
 export interface IMyService {
     /**
      * endpoint level docs

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -62,6 +62,7 @@ describe("simpleAst", () => {
                             type: "primitive",
                         },
                         tags: [],
+                        errors: [],
                     },
                 ],
                 serviceName: {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -135,7 +135,7 @@ export function generateService(
             returnType: `Promise<${returnTsType}>`,
             // this appears to be a no-op by ts-simple-ast, since default in typescript is public
             scope: Scope.Public,
-            docs: docs !== undefined ? [docs] : undefined,
+            docs: docs != null ? [docs] : undefined,
         });
     });
 
@@ -205,7 +205,7 @@ function generateEndpointBody(
     const requestMediaType =
         bodyArgs.length === 0 ? MediaType.APPLICATION_JSON : IType.visit(bodyArgs[0].type, mediaTypeVisitor);
     const responseMediaType =
-        endpointDefinition.returns !== undefined && endpointDefinition.returns !== null
+        endpointDefinition.returns != null && endpointDefinition.returns != null
             ? IType.visit(endpointDefinition.returns, mediaTypeVisitor)
             : MediaType.APPLICATION_JSON;
     const formattedHeaderArgs = headerArgs.map(argDefinition => {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -44,7 +44,7 @@ import { StringConversionTypeVisitor } from "./stringConversionTypeVisitor";
 import { TsArgumentTypeVisitor } from "./tsArgumentTypeVisitor";
 import { TsReturnTypeVisitor } from "./tsReturnTypeVisitor";
 import { ITypeGenerationFlags } from "./typeGenerationFlags";
-import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingDocs, CONJURE_CLIENT } from "./utils";
+import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingToDocs, CONJURE_CLIENT } from "./utils";
 
 /** Type used in the generation of the service class. Expected to be provided by conjure-client */
 const HTTP_API_BRIDGE_TYPE = "IHttpApiBridge";
@@ -115,7 +115,7 @@ export function generateService(
             returnType: `Promise<${returnTsType}>`,
         };
         let docs = addDeprecatedToDocs(endpointDefinition);
-        docs = addIncubatingDocs(endpointDefinition, docs);
+        docs = addIncubatingToDocs(endpointDefinition, docs);
         docs = addErrorsToDocs(endpointDefinition, docs);
         if (docs != null) {
             signature.docs = [docs];

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -44,7 +44,7 @@ import { StringConversionTypeVisitor } from "./stringConversionTypeVisitor";
 import { TsArgumentTypeVisitor } from "./tsArgumentTypeVisitor";
 import { TsReturnTypeVisitor } from "./tsReturnTypeVisitor";
 import { ITypeGenerationFlags } from "./typeGenerationFlags";
-import { addDeprecatedToDocs, addIncubatingDocs, CONJURE_CLIENT } from "./utils";
+import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingDocs, CONJURE_CLIENT } from "./utils";
 
 /** Type used in the generation of the service class. Expected to be provided by conjure-client */
 const HTTP_API_BRIDGE_TYPE = "IHttpApiBridge";
@@ -114,9 +114,11 @@ export function generateService(
             parameters,
             returnType: `Promise<${returnTsType}>`,
         };
-        const docs = addIncubatingDocs(endpointDefinition, addDeprecatedToDocs(endpointDefinition));
+        let docs = addDeprecatedToDocs(endpointDefinition);
+        docs = addIncubatingDocs(endpointDefinition, docs);
+        docs = addErrorsToDocs(endpointDefinition, docs);
         if (docs != null) {
-            signature.docs = docs;
+            signature.docs = [docs];
         }
         endpointSignatures.push(signature);
 
@@ -133,7 +135,7 @@ export function generateService(
             returnType: `Promise<${returnTsType}>`,
             // this appears to be a no-op by ts-simple-ast, since default in typescript is public
             scope: Scope.Public,
-            docs,
+            docs: docs !== undefined ? [docs] : undefined,
         });
     });
 

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -379,9 +379,9 @@ function processUnionMembers(
         functions.push({
             kind: StructureKind.Function,
             statements: `return {
-              ${memberName}: obj,
-              type: ${doubleQuote(memberName)},
-          };`,
+                ${memberName}: obj,
+                type: ${doubleQuote(memberName)},
+            };`,
             // TODO(gracew): ensure that memberName is lowercase?
             name: factoryName,
             parameters: [
@@ -405,8 +405,8 @@ function processUnionMembers(
             isReadonly: typeGenerationFlags.readonlyInterfaces,
         });
         visitorStatements.push(`if (${typeGuard.name}(${obj})) {
-          return ${visitor}.${memberName}(${obj}.${memberName});
-      }`);
+            return ${visitor}.${memberName}(${obj}.${memberName});
+        }`);
     });
 
     visitorProperties.push({

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -119,13 +119,16 @@ export async function generateEnum(definition: IEnumDefinition, simpleAst: Simpl
     const sourceFile = simpleAst.createSourceFile(definition.typeName);
 
     if (definition.values.length > 0) {
-        const typeAliases = definition.values.map<TypeAliasDeclarationStructure>(enumValue => ({
-            kind: StructureKind.TypeAlias,
-            isExported: true,
-            name: enumValue.value,
-            type: doubleQuote(enumValue.value),
-            docs: addDeprecatedToDocs(enumValue),
-        }));
+        const typeAliases = definition.values.map<TypeAliasDeclarationStructure>(enumValue => {
+            const docs = addDeprecatedToDocs(enumValue);
+            return {
+                kind: StructureKind.TypeAlias,
+                isExported: true,
+                name: enumValue.value,
+                type: doubleQuote(enumValue.value),
+                docs: docs !== undefined ? [docs] : undefined,
+            };
+        });
         typeAliases[typeAliases.length - 1].trailingTrivia = `\n\n`;
         const variableDeclarations = definition.values.map<VariableStatementStructure>(enumValue => ({
             kind: StructureKind.VariableStatement,
@@ -206,13 +209,14 @@ export async function generateObject(
     const imports: ImportDeclarationStructure[] = [];
     definition.fields.forEach(fieldDefinition => {
         const fieldType = IType.visit(fieldDefinition.type, tsTypeVisitor);
+        const docs = addDeprecatedToDocs(fieldDefinition);
 
         const property: PropertySignatureStructure = {
             kind: StructureKind.PropertySignature,
             hasQuestionToken: IType.isOptional(fieldDefinition.type),
             name: singleQuote(fieldDefinition.fieldName),
             type: fieldType,
-            docs: addDeprecatedToDocs(fieldDefinition),
+            docs: docs !== undefined ? [docs] : undefined,
             isReadonly: typeGenerationFlags.readonlyInterfaces,
         };
 
@@ -335,10 +339,11 @@ function processUnionMembers(
         imports.push(...IType.visit(fieldDefinition.type, importsVisitor));
 
         const interfaceName = `${unionTsType}_${uppercase(memberName)}`;
+        const docs = addDeprecatedToDocs(fieldDefinition);
 
         memberInterfaces.push({
             kind: StructureKind.Interface,
-            docs: addDeprecatedToDocs(fieldDefinition),
+            docs: docs !== undefined ? [docs] : undefined,
             isExported: true,
             name: interfaceName,
             properties: [
@@ -374,9 +379,9 @@ function processUnionMembers(
         functions.push({
             kind: StructureKind.Function,
             statements: `return {
-                ${memberName}: obj,
-                type: ${doubleQuote(memberName)},
-            };`,
+              ${memberName}: obj,
+              type: ${doubleQuote(memberName)},
+          };`,
             // TODO(gracew): ensure that memberName is lowercase?
             name: factoryName,
             parameters: [
@@ -400,8 +405,8 @@ function processUnionMembers(
             isReadonly: typeGenerationFlags.readonlyInterfaces,
         });
         visitorStatements.push(`if (${typeGuard.name}(${obj})) {
-            return ${visitor}.${memberName}(${obj}.${memberName});
-        }`);
+          return ${visitor}.${memberName}(${obj}.${memberName});
+      }`);
     });
 
     visitorProperties.push({

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -392,10 +392,7 @@ function processUnionMembers(
             ],
             returnType: interfaceName,
             // deprecate creation of deprecated types
-            docs:
-                fieldDefinition.deprecated != null && fieldDefinition.deprecated != null
-                    ? [`@deprecated ${fieldDefinition.deprecated}`]
-                    : undefined,
+            docs: fieldDefinition.deprecated != null ? [`@deprecated ${fieldDefinition.deprecated}`] : undefined,
         });
 
         visitorProperties.push({

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -126,7 +126,7 @@ export async function generateEnum(definition: IEnumDefinition, simpleAst: Simpl
                 isExported: true,
                 name: enumValue.value,
                 type: doubleQuote(enumValue.value),
-                docs: docs !== undefined ? [docs] : undefined,
+                docs: docs != null ? [docs] : undefined,
             };
         });
         typeAliases[typeAliases.length - 1].trailingTrivia = `\n\n`;
@@ -216,7 +216,7 @@ export async function generateObject(
             hasQuestionToken: IType.isOptional(fieldDefinition.type),
             name: singleQuote(fieldDefinition.fieldName),
             type: fieldType,
-            docs: docs !== undefined ? [docs] : undefined,
+            docs: docs != null ? [docs] : undefined,
             isReadonly: typeGenerationFlags.readonlyInterfaces,
         };
 
@@ -234,7 +234,7 @@ export async function generateObject(
         name: "I" + definition.typeName.name,
         properties,
     });
-    if (definition.docs !== undefined && definition.docs !== null) {
+    if (definition.docs != null && definition.docs != null) {
         iface.addJsDoc({ description: definition.docs });
     }
 
@@ -343,7 +343,7 @@ function processUnionMembers(
 
         memberInterfaces.push({
             kind: StructureKind.Interface,
-            docs: docs !== undefined ? [docs] : undefined,
+            docs: docs != null ? [docs] : undefined,
             isExported: true,
             name: interfaceName,
             properties: [
@@ -393,7 +393,7 @@ function processUnionMembers(
             returnType: interfaceName,
             // deprecate creation of deprecated types
             docs:
-                fieldDefinition.deprecated !== null && fieldDefinition.deprecated !== undefined
+                fieldDefinition.deprecated != null && fieldDefinition.deprecated != null
                     ? [`@deprecated ${fieldDefinition.deprecated}`]
                     : undefined,
         });

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -108,7 +108,7 @@ export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefin
         if (typeDefintion.docs != null && typeDefintion.docs != null) {
             // Do not add deprecated JSDoc if already exists
             if (typeDefintion.docs.indexOf("@deprecated") === -1) {
-                return typeDefintion.docs + "\n" + `@deprecated ${typeDefintion.deprecated}`;
+                return `${typeDefintion.docs}\n@deprecated ${typeDefintion.deprecated}`;
             }
         } else {
             return `@deprecated ${typeDefintion.deprecated}`;
@@ -123,11 +123,10 @@ export function addErrorsToDocs(
 ): string | undefined {
     if (endpointDefinition.errors != null && endpointDefinition.errors.length > 0) {
         if (existingDocs != null) {
-            return (
-                existingDocs +
-                "\n" +
-                endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n")
-            );
+            const formattedErrors = endpointDefinition.errors
+                .map(error => `@throws ${formattedEndpointError(error)}`)
+                .join("\n");
+            return `${existingDocs}\n${formattedErrors}`;
         } else {
             return endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n");
         }
@@ -143,7 +142,7 @@ export function addIncubatingDocs(
         if (existingDocs == null) {
             return "@incubating";
         } else {
-            return existingDocs + "\n" + "@incubating";
+            return `${existingDocs}\n@incubating`;
         }
     }
     return existingDocs;

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -117,6 +117,20 @@ export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefin
     return typeDefintion.docs != null ? typeDefintion.docs : undefined;
 }
 
+export function addIncubatingToDocs(
+    endpointDefinition: IEndpointDefinition,
+    existingDocs: string | undefined,
+): string | undefined {
+    if (endpointDefinition.tags != null && endpointDefinition.tags.indexOf("incubating") >= 0) {
+        if (existingDocs == null) {
+            return "@incubating";
+        } else {
+            return `${existingDocs}\n@incubating`;
+        }
+    }
+    return existingDocs;
+}
+
 export function addErrorsToDocs(
     endpointDefinition: IEndpointDefinition,
     existingDocs: string | undefined,
@@ -129,20 +143,6 @@ export function addErrorsToDocs(
             return `${existingDocs}\n${formattedErrors}`;
         } else {
             return endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n");
-        }
-    }
-    return existingDocs;
-}
-
-export function addIncubatingToDocs(
-    endpointDefinition: IEndpointDefinition,
-    existingDocs: string | undefined,
-): string | undefined {
-    if (endpointDefinition.tags != null && endpointDefinition.tags.indexOf("incubating") >= 0) {
-        if (existingDocs == null) {
-            return "@incubating";
-        } else {
-            return `${existingDocs}\n@incubating`;
         }
     }
     return existingDocs;

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -16,6 +16,7 @@
  */
 import {
     IEndpointDefinition,
+    IEndpointError,
     IEnumValueDefinition,
     IFieldDefinition,
     IType,
@@ -101,29 +102,51 @@ const strictModeReservedKeywords = new Set([
 ]);
 
 type DeprecatableDefinitions = IFieldDefinition | IEnumValueDefinition | IEndpointDefinition;
-export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefintion: T): string[] | undefined {
+
+export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefintion: T): string | undefined {
     if (typeDefintion.deprecated !== undefined && typeDefintion.deprecated !== null) {
         if (typeDefintion.docs !== undefined && typeDefintion.docs !== null) {
             // Do not add deprecated JSDoc if already exists
             if (typeDefintion.docs.indexOf("@deprecated") === -1) {
-                return [typeDefintion.docs + `\n@deprecated ${typeDefintion.deprecated}`];
+                return typeDefintion.docs + "\n" + `@deprecated ${typeDefintion.deprecated}`;
             }
         } else {
-            return [`@deprecated ${typeDefintion.deprecated}`];
+            return `@deprecated ${typeDefintion.deprecated}`;
         }
     }
-    return typeDefintion.docs != null ? [typeDefintion.docs] : undefined;
+    return typeDefintion.docs != null ? typeDefintion.docs : undefined;
+}
+
+export function addErrorsToDocs(
+    endpointDefinition: IEndpointDefinition,
+    existingDocs: string | undefined,
+): string | undefined {
+    if (endpointDefinition.errors !== undefined && endpointDefinition.errors.length > 0) {
+        if (existingDocs !== undefined) {
+            // Do not add @throws if documentation already includes information about thrown errors
+            if (existingDocs.indexOf("@throws") === -1) {
+                return (
+                    existingDocs +
+                    "\n" +
+                    endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n")
+                );
+            }
+        } else {
+            return endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n");
+        }
+    }
+    return existingDocs;
 }
 
 export function addIncubatingDocs(
     endpointDefinition: IEndpointDefinition,
-    existingDocs: string[] | undefined,
-): string[] | undefined {
+    existingDocs: string | undefined,
+): string | undefined {
     if (endpointDefinition.tags !== undefined && endpointDefinition.tags.indexOf("incubating") >= 0) {
         if (existingDocs === undefined) {
-            return [`@incubating`];
+            return "@incubating";
         } else {
-            return [existingDocs + `\n@incubating`];
+            return existingDocs + "\n" + "@incubating";
         }
     }
     return existingDocs;
@@ -138,4 +161,12 @@ const NON_FLAVORIZABLE_TYPES = new Set<PrimitiveType>([
 
 export function isFlavorizable(type: IType, flavorizedAliases: boolean): boolean {
     return flavorizedAliases && IType.isPrimitive(type) && !NON_FLAVORIZABLE_TYPES.has(type.primitive);
+}
+
+function formattedEndpointError(errorDefinition: IEndpointError): string {
+    let formattedString = `{${errorDefinition.error.name}}`;
+    if (errorDefinition.docs !== null && errorDefinition.docs !== undefined) {
+        formattedString += ` ${errorDefinition.docs}`;
+    }
+    return formattedString;
 }

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -134,7 +134,7 @@ export function addErrorsToDocs(
     return existingDocs;
 }
 
-export function addIncubatingDocs(
+export function addIncubatingToDocs(
     endpointDefinition: IEndpointDefinition,
     existingDocs: string | undefined,
 ): string | undefined {

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -104,8 +104,8 @@ const strictModeReservedKeywords = new Set([
 type DeprecatableDefinitions = IFieldDefinition | IEnumValueDefinition | IEndpointDefinition;
 
 export function addDeprecatedToDocs<T extends DeprecatableDefinitions>(typeDefintion: T): string | undefined {
-    if (typeDefintion.deprecated !== undefined && typeDefintion.deprecated !== null) {
-        if (typeDefintion.docs !== undefined && typeDefintion.docs !== null) {
+    if (typeDefintion.deprecated != null && typeDefintion.deprecated != null) {
+        if (typeDefintion.docs != null && typeDefintion.docs != null) {
             // Do not add deprecated JSDoc if already exists
             if (typeDefintion.docs.indexOf("@deprecated") === -1) {
                 return typeDefintion.docs + "\n" + `@deprecated ${typeDefintion.deprecated}`;
@@ -121,16 +121,13 @@ export function addErrorsToDocs(
     endpointDefinition: IEndpointDefinition,
     existingDocs: string | undefined,
 ): string | undefined {
-    if (endpointDefinition.errors !== undefined && endpointDefinition.errors.length > 0) {
-        if (existingDocs !== undefined) {
-            // Do not add @throws if documentation already includes information about thrown errors
-            if (existingDocs.indexOf("@throws") === -1) {
-                return (
-                    existingDocs +
-                    "\n" +
-                    endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n")
-                );
-            }
+    if (endpointDefinition.errors != null && endpointDefinition.errors.length > 0) {
+        if (existingDocs != null) {
+            return (
+                existingDocs +
+                "\n" +
+                endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n")
+            );
         } else {
             return endpointDefinition.errors.map(error => `@throws ${formattedEndpointError(error)}`).join("\n");
         }
@@ -142,8 +139,8 @@ export function addIncubatingDocs(
     endpointDefinition: IEndpointDefinition,
     existingDocs: string | undefined,
 ): string | undefined {
-    if (endpointDefinition.tags !== undefined && endpointDefinition.tags.indexOf("incubating") >= 0) {
-        if (existingDocs === undefined) {
+    if (endpointDefinition.tags != null && endpointDefinition.tags.indexOf("incubating") >= 0) {
+        if (existingDocs == null) {
             return "@incubating";
         } else {
             return existingDocs + "\n" + "@incubating";
@@ -165,7 +162,7 @@ export function isFlavorizable(type: IType, flavorizedAliases: boolean): boolean
 
 function formattedEndpointError(errorDefinition: IEndpointError): string {
     let formattedString = `{${errorDefinition.error.name}}`;
-    if (errorDefinition.docs !== null && errorDefinition.docs !== undefined) {
+    if (errorDefinition.docs != null && errorDefinition.docs != null) {
         formattedString += ` ${errorDefinition.docs}`;
     }
     return formattedString;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,7 +1614,7 @@ concat-map@0.0.1:
 
 conjure-api@^4.50.0:
   version "4.50.0"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/conjure-api/-/conjure-api-4.50.0.tgz#351795ccca6ab5598e630748a81ba8f8713b8cd2"
+  resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.50.0.tgz#351795ccca6ab5598e630748a81ba8f8713b8cd2"
   integrity sha512-YGqhW21t/Z/n/SKdyr5fNu8zqWYpnN+tp10+5ZEQw5f7heUv5sX84OuJc5Xq6G6J/4egbwRmS9R11ICvcLm9vA==
   dependencies:
     conjure-client "^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,10 +1612,12 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 
-conjure-api@^4.14.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/conjure-api/-/conjure-api-4.14.1.tgz#d999ca713b41fac6e56e35ba377ece8662e016b6"
-  integrity "sha1-2ZnKcTtB+sblbjW6N37OhmLgFrY= sha512-V3GpHzeT6uVRZalRwvncLGmZ2DiwESreojXhp8F24RxNERLkHcBzLgoxh+zjMxfAVAKsKtvR2jc76BLMLOZb+A=="
+conjure-api@^4.50.0:
+  version "4.50.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/conjure-api/-/conjure-api-4.50.0.tgz#351795ccca6ab5598e630748a81ba8f8713b8cd2"
+  integrity sha512-YGqhW21t/Z/n/SKdyr5fNu8zqWYpnN+tp10+5ZEQw5f7heUv5sX84OuJc5Xq6G6J/4egbwRmS9R11ICvcLm9vA==
+  dependencies:
+    conjure-client "^2.4.1"
 
 conjure-client@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Before this PR
JSDoc endpoint documentation did not include any information about thrown errors from the endpoints.

## After this PR
==COMMIT_MSG==
Endpoint thrown errors will be included in the JSDoc documentation for generated functions.
==COMMIT_MSG==

TODOs:
- [x] Generate changelog entry