### PR TITLE
Fix Generated Error Types in JSDoc

### DIFF
--- a/changelog/@unreleased/pr-299.v2.yml
+++ b/changelog/@unreleased/pr-299.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Change documented error types in JSDoc to reference the actual generated error types by Conjure
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/299

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -5,4 +5,8 @@ set -euo pipefail
 ./build/downloads/bin/conjure-verification-server ./build/resources/verification-server-test-cases.json ./build/resources/verification-server-api.conjure.json &
 SERVER_PID=$!
 yarn karma start --single-run --browsers ChromeHeadless karma.conf.js
-kill -kill ${SERVER_PID}
+
+if ps -p ${SERVER_PID} > /dev/null
+then
+    kill -kill ${SERVER_PID}
+fi

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -599,8 +599,8 @@ export interface IMyService {
 export interface IMyService {
     /**
      * endpoint level docs
-     * @throws {MyError1} MyError1 documentation
-     * @throws {MyError2} MyError2 documentation
+     * @throws {IMyError1} MyError1 documentation
+     * @throws {IMyError2} MyError2 documentation
      */
     foo(): Promise<void>;
 }
@@ -643,7 +643,7 @@ export interface IMyService {
     /**
      * endpoint level docs
      * @incubating
-     * @throws {MyError} MyError documentation
+     * @throws {IMyError} MyError documentation
      */
     foo(): Promise<void>;
 }

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -588,7 +588,28 @@ export interface IMyService {
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
             },
-            new Map(),
+            new Map([
+                [
+                    createHashableTypeName({
+                        name: "MyError1",
+                        package: "com.palantir.services",
+                    }),
+                    {
+                        type: "object",
+                        object: { typeName: { name: "MyError1", package: "com.palantir.services" }, fields: [] },
+                    },
+                ],
+                [
+                    createHashableTypeName({
+                        name: "MyError2",
+                        package: "com.palantir.services",
+                    }),
+                    {
+                        type: "object",
+                        object: { typeName: { name: "MyError2", package: "com.palantir.services" }, fields: [] },
+                    },
+                ],
+            ]),
             simpleAst,
             DEFAULT_TYPE_GENERATION_FLAGS,
         );
@@ -631,7 +652,18 @@ export interface IMyService {
                 ],
                 serviceName: { name: "MyService", package: "com.palantir.services" },
             },
-            new Map(),
+            new Map([
+                [
+                    createHashableTypeName({
+                        name: "MyError",
+                        package: "com.palantir.services",
+                    }),
+                    {
+                        type: "object",
+                        object: { typeName: { name: "MyError", package: "com.palantir.services" }, fields: [] },
+                    },
+                ],
+            ]),
             simpleAst,
             DEFAULT_TYPE_GENERATION_FLAGS,
         );

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -590,20 +590,14 @@ export interface IMyService {
             },
             new Map([
                 [
-                    createHashableTypeName({
-                        name: "MyError1",
-                        package: "com.palantir.services",
-                    }),
+                    createHashableTypeName({ name: "MyError1", package: "com.palantir.services" }),
                     {
                         type: "object",
                         object: { typeName: { name: "MyError1", package: "com.palantir.services" }, fields: [] },
                     },
                 ],
                 [
-                    createHashableTypeName({
-                        name: "MyError2",
-                        package: "com.palantir.services",
-                    }),
+                    createHashableTypeName({ name: "MyError2", package: "com.palantir.services" }),
                     {
                         type: "object",
                         object: { typeName: { name: "MyError2", package: "com.palantir.services" }, fields: [] },
@@ -654,10 +648,7 @@ export interface IMyService {
             },
             new Map([
                 [
-                    createHashableTypeName({
-                        name: "MyError",
-                        package: "com.palantir.services",
-                    }),
+                    createHashableTypeName({ name: "MyError", package: "com.palantir.services" }),
                     {
                         type: "object",
                         object: { typeName: { name: "MyError", package: "com.palantir.services" }, fields: [] },
@@ -802,10 +793,7 @@ export interface IMyService {
             },
             new Map([
                 [
-                    createHashableTypeName({
-                        name: "MyError",
-                        package: "com.palantir.errors",
-                    }),
+                    createHashableTypeName({ name: "MyError", package: "com.palantir.errors" }),
                     {
                         type: "object",
                         object: { typeName: { name: "MyError", package: "com.palantir.errors" }, fields: [] },

--- a/src/commands/generate/__tests__/serviceGeneratorTest.ts
+++ b/src/commands/generate/__tests__/serviceGeneratorTest.ts
@@ -806,7 +806,7 @@ export interface IMyService {
         const outFile = path.join(outDir, "services/myService.ts");
         const contents = fs.readFileSync(outFile, "utf8");
 
-        expect(contents).toContain(`import { IMyError } from "../errors/myError";
+        expect(contents).toContain(`import type { IMyError } from "../errors/myError";
 import { IHttpApiBridge } from "conjure-client";
 
 /** Constant reference to \`undefined\` that we expect to get minified and therefore reduce total code size */

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -23,8 +23,8 @@ import { generateError } from "../errorGenerator";
 import { generateService } from "../serviceGenerator";
 import { SimpleAst } from "../simpleAst";
 import { generateEnum } from "../typeGenerator";
-import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 import { createHashableTypeName } from "../utils";
+import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
 
 describe("simpleAst", () => {
     let outDir: string;
@@ -36,7 +36,6 @@ describe("simpleAst", () => {
     });
 
     it("generate index file with multiple packages.", async () => {
-        console.log("INDEX:", outDir);
         await generateError(
             {
                 code: ErrorCode.INVALID_ARGUMENT,

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -81,10 +81,7 @@ describe("simpleAst", () => {
             },
             new Map([
                 [
-                    createHashableTypeName({
-                        name: "MyError",
-                        package: "com.palantir.package1",
-                    }),
+                    createHashableTypeName({ name: "MyError", package: "com.palantir.package1" }),
                     {
                         type: "object",
                         object: { typeName: { name: "MyError", package: "com.palantir.package1" }, fields: [] },

--- a/src/commands/generate/__tests__/simpleAstTest.ts
+++ b/src/commands/generate/__tests__/simpleAstTest.ts
@@ -24,6 +24,7 @@ import { generateService } from "../serviceGenerator";
 import { SimpleAst } from "../simpleAst";
 import { generateEnum } from "../typeGenerator";
 import { DEFAULT_TYPE_GENERATION_FLAGS } from "./resources/constants";
+import { createHashableTypeName } from "../utils";
 
 describe("simpleAst", () => {
     let outDir: string;
@@ -35,6 +36,7 @@ describe("simpleAst", () => {
     });
 
     it("generate index file with multiple packages.", async () => {
+        console.log("INDEX:", outDir);
         await generateError(
             {
                 code: ErrorCode.INVALID_ARGUMENT,
@@ -62,7 +64,15 @@ describe("simpleAst", () => {
                             type: "primitive",
                         },
                         tags: [],
-                        errors: [],
+                        errors: [
+                            {
+                                error: {
+                                    name: "MyError",
+                                    package: "com.palantir.package1",
+                                    namespace: "Metadata",
+                                },
+                            },
+                        ],
                     },
                 ],
                 serviceName: {
@@ -70,7 +80,18 @@ describe("simpleAst", () => {
                     package: "com.palantir.package2",
                 },
             },
-            new Map(),
+            new Map([
+                [
+                    createHashableTypeName({
+                        name: "MyError",
+                        package: "com.palantir.package1",
+                    }),
+                    {
+                        type: "object",
+                        object: { typeName: { name: "MyError", package: "com.palantir.package1" }, fields: [] },
+                    },
+                ],
+            ]),
             simpleAst,
             DEFAULT_TYPE_GENERATION_FLAGS,
         );

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -140,6 +140,7 @@ export function generateService(
 
         endpointDefinition.errors?.forEach(error => {
             imports.push(
+                // TODO: Get rid of the visitor, because the type (reference) is already known
                 ...IType.visit(
                     {
                         reference: {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -137,6 +137,21 @@ export function generateService(
             scope: Scope.Public,
             docs: docs != null ? [docs] : undefined,
         });
+
+        endpointDefinition.errors?.forEach(error => {
+            imports.push(
+                ...IType.visit(
+                    {
+                        reference: {
+                            name: `${error.error.name}`,
+                            package: error.error.package,
+                        },
+                        type: "reference",
+                    },
+                    importsVisitor,
+                ),
+            );
+        });
     });
 
     if (imports.length !== 0) {

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -139,19 +139,18 @@ export function generateService(
         });
 
         endpointDefinition.errors?.forEach(error => {
-            imports.push(
-                // TODO: Get rid of the visitor, because the type (reference) is already known
-                ...IType.visit(
-                    {
-                        reference: {
-                            name: `${error.error.name}`,
-                            package: error.error.package,
-                        },
-                        type: "reference",
+            // TODO: Get rid of the visitor, because the type (reference) is already known
+            const errorImports: ImportDeclarationStructure[] = IType.visit(
+                {
+                    reference: {
+                        name: `${error.error.name}`,
+                        package: error.error.package,
                     },
-                    importsVisitor,
-                ),
-            );
+                    type: "reference",
+                },
+                importsVisitor,
+            ).map(i => ({ ...i, isTypeOnly: true }));
+            imports.push(...errorImports);
         });
     });
 

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -160,7 +160,7 @@ export function isFlavorizable(type: IType, flavorizedAliases: boolean): boolean
 }
 
 function formattedEndpointError(errorDefinition: IEndpointError): string {
-    let formattedString = `{${errorDefinition.error.name}}`;
+    let formattedString = `{I${errorDefinition.error.name}}`;
     if (errorDefinition.docs != null && errorDefinition.docs != null) {
         formattedString += ` ${errorDefinition.docs}`;
     }


### PR DESCRIPTION
## Before this PR
The documented error types in JSDoc did not reference actual TS types.

## After this PR
==COMMIT_MSG==
Change documented error types in JSDoc to reference the actual generated error types by Conjure
==COMMIT_MSG==

---

Relate PR: https://github.com/palantir/conjure-typescript/pull/294
