### PR TITLE
Fix error imports

### DIFF
--- a/changelog/@unreleased/pr-300.v2.yml
+++ b/changelog/@unreleased/pr-300.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed an issue where importing errors was causing the generator to crash
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/300

--- a/src/commands/generate/generator.ts
+++ b/src/commands/generate/generator.ts
@@ -41,9 +41,20 @@ export async function generate(
     typeGenerationFlags: ITypeGenerationFlags,
 ) {
     // Create project structure
-    const knownTypes = new Map();
+    const knownTypes: Map<string, ITypeDefinition> = new Map();
     const indexingVisitor = new IndexByTypeNameVisitor(knownTypes);
     definition.types.forEach(typeDefinition => ITypeDefinition.visit(typeDefinition, indexingVisitor));
+    // Add the errors to knownTypes so they can be imported by services
+    definition.errors.forEach(errorDefinition =>
+        knownTypes.set(
+            createHashableTypeName(errorDefinition.errorName),
+            ITypeDefinition.object({
+                typeName: errorDefinition.errorName,
+                docs: errorDefinition.docs,
+                fields: [], // We don't need to know an error's fields to import an error
+            }),
+        ),
+    );
     const knownDefinitions = Array.from(knownTypes.keys())
         .map(dissasembleHashableTypeName)
         .concat(definition.services.map(serviceDefinition => serviceDefinition.serviceName))

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -143,7 +143,7 @@ export function generateService(
             const errorImports: ImportDeclarationStructure[] = IType.visit(
                 {
                     reference: {
-                        name: `${error.error.name}`,
+                        name: error.error.name,
                         package: error.error.package,
                     },
                     type: "reference",

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -140,17 +140,22 @@ export function generateService(
 
         endpointDefinition.errors?.forEach(error => {
             // TODO: Get rid of the visitor, because the type (reference) is already known
-            const errorImports: ImportDeclarationStructure[] = IType.visit(
-                {
-                    reference: {
-                        name: error.error.name,
-                        package: error.error.package,
+            try {
+                const errorImports: ImportDeclarationStructure[] = IType.visit(
+                    {
+                        reference: {
+                            name: error.error.name,
+                            package: error.error.package,
+                        },
+                        type: "reference",
                     },
-                    type: "reference",
-                },
-                importsVisitor,
-            ).map(i => ({ ...i, isTypeOnly: true }));
-            imports.push(...errorImports);
+                    importsVisitor,
+                ).map(i => ({ ...i, isTypeOnly: true }));
+                imports.push(...errorImports);
+            } catch (e) {
+                // Error could not be imported...
+                console.error(e);
+            }
         });
     });
 

--- a/src/commands/generate/serviceGenerator.ts
+++ b/src/commands/generate/serviceGenerator.ts
@@ -140,22 +140,17 @@ export function generateService(
 
         endpointDefinition.errors?.forEach(error => {
             // TODO: Get rid of the visitor, because the type (reference) is already known
-            try {
-                const errorImports: ImportDeclarationStructure[] = IType.visit(
-                    {
-                        reference: {
-                            name: error.error.name,
-                            package: error.error.package,
-                        },
-                        type: "reference",
+            const errorImports: ImportDeclarationStructure[] = IType.visit(
+                {
+                    reference: {
+                        name: error.error.name,
+                        package: error.error.package,
                     },
-                    importsVisitor,
-                ).map(i => ({ ...i, isTypeOnly: true }));
-                imports.push(...errorImports);
-            } catch (e) {
-                // Error could not be imported...
-                console.error(e);
-            }
+                    type: "reference",
+                },
+                importsVisitor,
+            ).map(i => ({ ...i, isTypeOnly: true }));
+            imports.push(...errorImports);
         });
     });
 


### PR DESCRIPTION
This PR fixes an issue with error imports. Errors were previously not added to the map of known types which lead to the `ImportsVisitor` throwing when an error type could not be imported.