### PR TITLE
Fix up union recursive type logic

### DIFF
--- a/changelog/@unreleased/pr-301.v2.yml
+++ b/changelog/@unreleased/pr-301.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Referencing a type with the same name in another package will correctly
+    be resolved instead of referencing the self type.
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/301

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -192,20 +192,18 @@ describe("TsTypeVisitor", () => {
             const unionName = { name: fakeTypeName.name, package: "" };
             const union = ITypeDefinition.union({
                 typeName: unionName,
-                union: []
+                union: [],
             });
 
             const unionVisitor = new TsReturnTypeVisitor(
-                new Map<string, ITypeDefinition>([
-                    [createHashableTypeName(unionName), union],
-                ]),
+                new Map<string, ITypeDefinition>([[createHashableTypeName(unionName), union]]),
                 fakeTypeName,
                 false,
                 DEFAULT_TYPE_GENERATION_FLAGS,
             );
 
             expect(unionVisitor.reference(unionName)).toEqual(`I${unionName.name}.I${unionName.name}`);
-        })
+        });
     });
 
     describe("with flavored generation flags", () => {

--- a/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
+++ b/src/commands/generate/__tests__/tsReturnTypeVisitorTest.ts
@@ -185,6 +185,27 @@ describe("TsTypeVisitor", () => {
             };
             expect(visitor.external(externalType)).toEqual("Array<IObject>");
         });
+
+        it("handles references to a union in another package with the same name", () => {
+            // unionName shares a name with fakeTypeName, but crucially it is a different package
+            // when we generate a reference to the other type, it needs to be namespaced instead of trying to use the local version
+            const unionName = { name: fakeTypeName.name, package: "" };
+            const union = ITypeDefinition.union({
+                typeName: unionName,
+                union: []
+            });
+
+            const unionVisitor = new TsReturnTypeVisitor(
+                new Map<string, ITypeDefinition>([
+                    [createHashableTypeName(unionName), union],
+                ]),
+                fakeTypeName,
+                false,
+                DEFAULT_TYPE_GENERATION_FLAGS,
+            );
+
+            expect(unionVisitor.reference(unionName)).toEqual(`I${unionName.name}.I${unionName.name}`);
+        })
     });
 
     describe("with flavored generation flags", () => {

--- a/src/commands/generate/tsReturnTypeVisitor.ts
+++ b/src/commands/generate/tsReturnTypeVisitor.ts
@@ -105,7 +105,7 @@ export class TsReturnTypeVisitor implements ITypeVisitor<string> {
             return obj.name;
         } else if (ITypeDefinition.isUnion(typeDefinition)) {
             // If the type reference is recursive, use a direct reference rather than a namespaced one
-            if (obj.name === this.currType.name && obj.package === obj.package) {
+            if (obj.name === this.currType.name && obj.package === this.currType.package) {
                 return withIPrefix;
             }
             return `${withIPrefix}.${withIPrefix}`;


### PR DESCRIPTION
## Before this PR
The second half of the `if` test is just always true, I suspect it should have tested against `currType` instead.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Referencing a type with the same name in another package will correctly be resolved instead of referencing the self type.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

