### PR TITLE
Add type assignment for empty union generations

### DIFF
--- a/changelog/@unreleased/pr-302.v2.yml
+++ b/changelog/@unreleased/pr-302.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix the bug where `compileTypeScript` task fails for empty unions
+  links:
+  - https://github.com/palantir/conjure-typescript/pull/302

--- a/src/commands/generate/__tests__/resources/definitions/example-types.yml
+++ b/src/commands/generate/__tests__/resources/definitions/example-types.yml
@@ -163,6 +163,8 @@ types:
           if: integer # some 'bad' member names!
           new: integer
           interface: integer
+      EmptyUnionTypeExample:
+        union: {}
       EmptyObjectExample:
         fields: {}
       AliasAsMapKeyExample:

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,4 +1,4 @@
-export type IEmptyUnionTypeExample = any;
+export type IEmptyUnionTypeExample = unknown;
 
 export interface IEmptyUnionTypeExampleVisitor<T> {
     'unknown': (obj: IEmptyUnionTypeExample) => T;

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,0 +1,13 @@
+export type IEmptyUnionTypeExample = any;
+
+export interface IEmptyUnionTypeExampleVisitor<T> {
+    'unknown': (obj: IEmptyUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IEmptyUnionTypeExample, visitor: IEmptyUnionTypeExampleVisitor<T>): T {
+    return visitor.unknown(obj);
+}
+
+export const IEmptyUnionTypeExample = {
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,4 +1,4 @@
-export type IEmptyUnionTypeExample = any;
+export type IEmptyUnionTypeExample = unknown;
 
 export interface IEmptyUnionTypeExampleVisitor<T> {
     readonly 'unknown': (obj: IEmptyUnionTypeExample) => T;

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,0 +1,13 @@
+export type IEmptyUnionTypeExample = any;
+
+export interface IEmptyUnionTypeExampleVisitor<T> {
+    readonly 'unknown': (obj: IEmptyUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IEmptyUnionTypeExample, visitor: IEmptyUnionTypeExampleVisitor<T>): T {
+    return visitor.unknown(obj);
+}
+
+export const IEmptyUnionTypeExample = {
+    visit: visit
+};

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,4 +1,4 @@
-export type IEmptyUnionTypeExample = any;
+export type IEmptyUnionTypeExample = unknown;
 
 export interface IEmptyUnionTypeExampleVisitor<T> {
     'unknown': (obj: IEmptyUnionTypeExample) => T;

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/emptyUnionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/emptyUnionTypeExample.ts
@@ -1,0 +1,13 @@
+export type IEmptyUnionTypeExample = any;
+
+export interface IEmptyUnionTypeExampleVisitor<T> {
+    'unknown': (obj: IEmptyUnionTypeExample) => T;
+}
+
+function visit<T>(obj: IEmptyUnionTypeExample, visitor: IEmptyUnionTypeExampleVisitor<T>): T {
+    return visitor.unknown(obj);
+}
+
+export const IEmptyUnionTypeExample = {
+    visit: visit
+};

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -269,7 +269,7 @@ export async function generateUnion(
         name: unionTsType,
         type:
             unionSourceFileInput.memberInterfaces.length === 0
-                ? "any"
+                ? "unknown"
                 : unionSourceFileInput.memberInterfaces.map(iface => iface.name).join(" | "),
     });
 

--- a/src/commands/generate/typeGenerator.ts
+++ b/src/commands/generate/typeGenerator.ts
@@ -267,7 +267,10 @@ export async function generateUnion(
         docs: definition.docs != null ? [{ description: definition.docs }] : undefined,
         isExported: true,
         name: unionTsType,
-        type: unionSourceFileInput.memberInterfaces.map(iface => iface.name).join(" | "),
+        type:
+            unionSourceFileInput.memberInterfaces.length === 0
+                ? "any"
+                : unionSourceFileInput.memberInterfaces.map(iface => iface.name).join(" | "),
     });
 
     const visitorInterface = sourceFile.addInterface({


### PR DESCRIPTION
## Before this PR
Fixes https://github.com/palantir/conjure-typescript/issues/296.

I've compared the output from a working old version of conjure-typescript and the current one. It turns out that type assignment is being skipped for empty unions and that's the issue:

```
export type IMyEmptyUnion = any;
                         ^^^^^^
                  This part was missing.
```

## After this PR
==COMMIT_MSG==
Fix the bug where `compileTypeScript` task fails for empty unions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

