### PR TITLE
Replace TypeScript parameter properties with explicit property declarations

### DIFF
--- a/src/commands/generate/__tests__/generateNonThrowingServiceTest.ts
+++ b/src/commands/generate/__tests__/generateNonThrowingServiceTest.ts
@@ -124,7 +124,10 @@ export interface IMyServiceWithErrors {
 }`);
         expect(contents).toContain(`
 export class MyServiceWithErrors implements IMyServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public returnsVoid(): Promise<IConjureResult<void, never>> {

--- a/src/commands/generate/__tests__/generateThrowingServiceTest.ts
+++ b/src/commands/generate/__tests__/generateThrowingServiceTest.ts
@@ -124,7 +124,10 @@ export interface IMyService {
 }`);
         expect(contents).toContain(`
 export class MyService implements IMyService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public returnsVoid(): Promise<void> {

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
@@ -44,7 +44,10 @@ export interface ITestService {
 }
 
 export class TestService implements ITestService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     /**

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-service/another/testService.ts
@@ -43,7 +43,10 @@ export interface ITestService {
 }
 
 export class TestService implements ITestService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     /**

--- a/src/commands/generate/__tests__/resources/services/optionalService.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalService.ts
@@ -8,7 +8,10 @@ export interface IOptionalService {
 }
 
 export class OptionalService implements IOptionalService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(header: string, name?: string | null): Promise<void> {

--- a/src/commands/generate/__tests__/resources/services/optionalServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/services/optionalServiceWithErrors.ts
@@ -8,7 +8,10 @@ export interface IOptionalServiceWithErrors {
 }
 
 export class OptionalServiceWithErrors implements IOptionalServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(header: string, name?: string | null): Promise<IConjureResult<void, never>> {

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathService.ts
@@ -8,7 +8,10 @@ export interface IOutOfOrderPathService {
 }
 
 export class OutOfOrderPathService implements IOutOfOrderPathService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(param1: string, param2: string): Promise<void> {

--- a/src/commands/generate/__tests__/resources/services/outOfOrderPathServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/services/outOfOrderPathServiceWithErrors.ts
@@ -8,7 +8,10 @@ export interface IOutOfOrderPathServiceWithErrors {
 }
 
 export class OutOfOrderPathServiceWithErrors implements IOutOfOrderPathServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(param1: string, param2: string): Promise<IConjureResult<void, never>> {

--- a/src/commands/generate/__tests__/resources/services/paramTypeService.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeService.ts
@@ -8,7 +8,10 @@ export interface IParamTypeService {
 }
 
 export class ParamTypeService implements IParamTypeService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(body: string, header: string, path: string, query: string): Promise<void> {

--- a/src/commands/generate/__tests__/resources/services/paramTypeServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/services/paramTypeServiceWithErrors.ts
@@ -8,7 +8,10 @@ export interface IParamTypeServiceWithErrors {
 }
 
 export class ParamTypeServiceWithErrors implements IParamTypeServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(body: string, header: string, path: string, query: string): Promise<IConjureResult<void, never>> {

--- a/src/commands/generate/__tests__/resources/services/primitiveService.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveService.ts
@@ -8,7 +8,10 @@ export interface IPrimitiveService {
 }
 
 export class PrimitiveService implements IPrimitiveService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public getPrimitive(): Promise<number> {

--- a/src/commands/generate/__tests__/resources/services/primitiveServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/services/primitiveServiceWithErrors.ts
@@ -8,7 +8,10 @@ export interface IPrimitiveServiceWithErrors {
 }
 
 export class PrimitiveServiceWithErrors implements IPrimitiveServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public getPrimitive(): Promise<IConjureResult<number, never>> {

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeader.ts
@@ -8,7 +8,10 @@ export interface IServiceWithSafelongHeader {
 }
 
 export class ServiceWithSafelongHeader implements IServiceWithSafelongHeader {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(investigation: number): Promise<void> {

--- a/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeaderWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/services/serviceWithSafelongHeaderWithErrors.ts
@@ -8,7 +8,10 @@ export interface IServiceWithSafelongHeaderWithErrors {
 }
 
 export class ServiceWithSafelongHeaderWithErrors implements IServiceWithSafelongHeaderWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public foo(investigation: number): Promise<IConjureResult<void, never>> {

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -43,7 +43,10 @@ export interface ITestService {
 }
 
 export class TestService implements ITestService {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     /**

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testServiceWithErrors.ts
@@ -46,7 +46,10 @@ export interface ITestServiceWithErrors {
 }
 
 export class TestServiceWithErrors implements ITestServiceWithErrors {
-    constructor(private bridge: IHttpApiBridge) {
+    private bridge: IHttpApiBridge;
+
+    constructor(bridge: IHttpApiBridge) {
+        this.bridge = bridge;
     }
 
     public getFileSystems(): Promise<IConjureResult<{ [key: string]: IBackingFileSystem }, never>> {

--- a/src/commands/generate/generators/generateNonThrowingService.ts
+++ b/src/commands/generate/generators/generateNonThrowingService.ts
@@ -187,15 +187,22 @@ export function generateNonThrowingService(
     }
 
     sourceFile.addClass({
+        properties: [
+            {
+                name: BRIDGE,
+                scope: Scope.Private,
+                type: HTTP_API_BRIDGE_TYPE,
+            },
+        ],
         ctors: [
             {
                 parameters: [
                     {
                         name: BRIDGE,
-                        scope: Scope.Private,
                         type: HTTP_API_BRIDGE_TYPE,
                     },
                 ],
+                statements: [`this.${BRIDGE} = ${BRIDGE};`],
             },
         ],
         isExported: true,

--- a/src/commands/generate/generators/generateThrowingService.ts
+++ b/src/commands/generate/generators/generateThrowingService.ts
@@ -153,15 +153,22 @@ export function generateThrowingService(
     }
 
     sourceFile.addClass({
+        properties: [
+            {
+                name: BRIDGE,
+                scope: Scope.Private,
+                type: HTTP_API_BRIDGE_TYPE,
+            },
+        ],
         ctors: [
             {
                 parameters: [
                     {
                         name: BRIDGE,
-                        scope: Scope.Private,
                         type: HTTP_API_BRIDGE_TYPE,
                     },
                 ],
+                statements: [`this.${BRIDGE} = ${BRIDGE};`],
             },
         ],
         isExported: true,


### PR DESCRIPTION
## Before this PR

TypeScript parameter properties (`constructor(private prop: Type)`) are not  supported in strip-only mode, causing runtime errors.

## After this PR

This change modifies  the code generators to emit explicit property declarations and assignments instead.

```typescript
private bridge: IHttpApiBridge;
constructor(bridge: IHttpApiBridge) {
  this.bridge = bridge;
}
```

Changes:
- Modified generateNonThrowingService.ts and generateThrowingService.ts to use explicit property declarations
- Updated all test expectations using `RECREATE=true` flag
- Fixed hardcoded test assertions to expect new constructor format

This ensures generated TypeScript services are compatible with strip-only mode while maintaining identical runtime behavior.

```
==COMMIT_MSG==
Replace TypeScript parameter properties with explicit property declarations

TypeScript parameter properties (constructor(private prop: Type)) are not 
supported in strip-only mode, causing runtime errors. This change modifies 
the code generators to emit explicit property declarations and assignments 
instead.

Changes:
- Modified generateNonThrowingService.ts and generateThrowingService.ts to use explicit property declarations
- Updated all test expectations using RECREATE=true flag
- Fixed hardcoded test assertions to expect new constructor format

Before: constructor(private bridge: IHttpApiBridge) {}
After:  private bridge: IHttpApiBridge; constructor(bridge: IHttpApiBridge) { this.bridge = bridge; }

This ensures generated TypeScript services are compatible with strip-only mode while maintaining identical runtime behavior.
==COMMIT_MSG==
```

## Possible downsides?

None come to mind.