### PR TITLE
Switch-based visit for union types

### DIFF
--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/deprecatedUnion.ts
@@ -63,16 +63,12 @@ export interface IDeprecatedUnionVisitor<T> {
 }
 
 function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
-    if (isGood(obj)) {
-        return visitor.good(obj.good);
+    switch (obj.type) {
+        case "good": return visitor.good(obj.good);
+        case "noGood": return visitor.noGood(obj.noGood);
+        case "noGoodDoc": return visitor.noGoodDoc(obj.noGoodDoc);
+        default: return visitor.unknown(obj);
     }
-    if (isNoGood(obj)) {
-        return visitor.noGood(obj.noGood);
-    }
-    if (isNoGoodDoc(obj)) {
-        return visitor.noGoodDoc(obj.noGoodDoc);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IDeprecatedUnion = {

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/singleUnion.ts
@@ -22,10 +22,10 @@ export interface ISingleUnionVisitor<T> {
 }
 
 function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        default: return visitor.unknown(obj);
     }
-    return visitor.unknown(obj);
 }
 
 export const ISingleUnion = {

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/union.ts
@@ -56,16 +56,12 @@ export interface IUnionVisitor<T> {
 }
 
 function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        case "bar": return visitor.bar(obj.bar);
+        case "baz": return visitor.baz(obj.baz);
+        default: return visitor.unknown(obj);
     }
-    if (isBar(obj)) {
-        return visitor.bar(obj.bar);
-    }
-    if (isBaz(obj)) {
-        return visitor.baz(obj.baz);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnion = {

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-types/product/unionTypeExample.ts
@@ -128,28 +128,16 @@ export interface IUnionTypeExampleVisitor<T> {
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
-    if (isStringExample(obj)) {
-        return visitor.stringExample(obj.stringExample);
+    switch (obj.type) {
+        case "stringExample": return visitor.stringExample(obj.stringExample);
+        case "set": return visitor.set(obj.set);
+        case "thisFieldIsAnInteger": return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+        case "alsoAnInteger": return visitor.alsoAnInteger(obj.alsoAnInteger);
+        case "if": return visitor.if(obj.if);
+        case "new": return visitor.new(obj.new);
+        case "interface": return visitor.interface(obj.interface);
+        default: return visitor.unknown(obj);
     }
-    if (isSet(obj)) {
-        return visitor.set(obj.set);
-    }
-    if (isThisFieldIsAnInteger(obj)) {
-        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
-    }
-    if (isAlsoAnInteger(obj)) {
-        return visitor.alsoAnInteger(obj.alsoAnInteger);
-    }
-    if (isIf(obj)) {
-        return visitor.if(obj.if);
-    }
-    if (isNew(obj)) {
-        return visitor.new(obj.new);
-    }
-    if (isInterface(obj)) {
-        return visitor.interface(obj.interface);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnionTypeExample = {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/deprecatedUnion.ts
@@ -63,16 +63,12 @@ export interface IDeprecatedUnionVisitor<T> {
 }
 
 function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
-    if (isGood(obj)) {
-        return visitor.good(obj.good);
+    switch (obj.type) {
+        case "good": return visitor.good(obj.good);
+        case "noGood": return visitor.noGood(obj.noGood);
+        case "noGoodDoc": return visitor.noGoodDoc(obj.noGoodDoc);
+        default: return visitor.unknown(obj);
     }
-    if (isNoGood(obj)) {
-        return visitor.noGood(obj.noGood);
-    }
-    if (isNoGoodDoc(obj)) {
-        return visitor.noGoodDoc(obj.noGoodDoc);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IDeprecatedUnion = {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/singleUnion.ts
@@ -22,10 +22,10 @@ export interface ISingleUnionVisitor<T> {
 }
 
 function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        default: return visitor.unknown(obj);
     }
-    return visitor.unknown(obj);
 }
 
 export const ISingleUnion = {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/union.ts
@@ -56,16 +56,12 @@ export interface IUnionVisitor<T> {
 }
 
 function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        case "bar": return visitor.bar(obj.bar);
+        case "baz": return visitor.baz(obj.baz);
+        default: return visitor.unknown(obj);
     }
-    if (isBar(obj)) {
-        return visitor.bar(obj.bar);
-    }
-    if (isBaz(obj)) {
-        return visitor.baz(obj.baz);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnion = {

--- a/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/readonly-test-cases/example-types/product/unionTypeExample.ts
@@ -128,28 +128,16 @@ export interface IUnionTypeExampleVisitor<T> {
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
-    if (isStringExample(obj)) {
-        return visitor.stringExample(obj.stringExample);
+    switch (obj.type) {
+        case "stringExample": return visitor.stringExample(obj.stringExample);
+        case "set": return visitor.set(obj.set);
+        case "thisFieldIsAnInteger": return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+        case "alsoAnInteger": return visitor.alsoAnInteger(obj.alsoAnInteger);
+        case "if": return visitor.if(obj.if);
+        case "new": return visitor.new(obj.new);
+        case "interface": return visitor.interface(obj.interface);
+        default: return visitor.unknown(obj);
     }
-    if (isSet(obj)) {
-        return visitor.set(obj.set);
-    }
-    if (isThisFieldIsAnInteger(obj)) {
-        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
-    }
-    if (isAlsoAnInteger(obj)) {
-        return visitor.alsoAnInteger(obj.alsoAnInteger);
-    }
-    if (isIf(obj)) {
-        return visitor.if(obj.if);
-    }
-    if (isNew(obj)) {
-        return visitor.new(obj.new);
-    }
-    if (isInterface(obj)) {
-        return visitor.interface(obj.interface);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnionTypeExample = {

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/deprecatedUnion.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/deprecatedUnion.ts
@@ -63,16 +63,12 @@ export interface IDeprecatedUnionVisitor<T> {
 }
 
 function visit<T>(obj: IDeprecatedUnion, visitor: IDeprecatedUnionVisitor<T>): T {
-    if (isGood(obj)) {
-        return visitor.good(obj.good);
+    switch (obj.type) {
+        case "good": return visitor.good(obj.good);
+        case "noGood": return visitor.noGood(obj.noGood);
+        case "noGoodDoc": return visitor.noGoodDoc(obj.noGoodDoc);
+        default: return visitor.unknown(obj);
     }
-    if (isNoGood(obj)) {
-        return visitor.noGood(obj.noGood);
-    }
-    if (isNoGoodDoc(obj)) {
-        return visitor.noGoodDoc(obj.noGoodDoc);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IDeprecatedUnion = {

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/singleUnion.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/singleUnion.ts
@@ -22,10 +22,10 @@ export interface ISingleUnionVisitor<T> {
 }
 
 function visit<T>(obj: ISingleUnion, visitor: ISingleUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        default: return visitor.unknown(obj);
     }
-    return visitor.unknown(obj);
 }
 
 export const ISingleUnion = {

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/union.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/union.ts
@@ -56,16 +56,12 @@ export interface IUnionVisitor<T> {
 }
 
 function visit<T>(obj: IUnion, visitor: IUnionVisitor<T>): T {
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
+    switch (obj.type) {
+        case "foo": return visitor.foo(obj.foo);
+        case "bar": return visitor.bar(obj.bar);
+        case "baz": return visitor.baz(obj.baz);
+        default: return visitor.unknown(obj);
     }
-    if (isBar(obj)) {
-        return visitor.bar(obj.bar);
-    }
-    if (isBaz(obj)) {
-        return visitor.baz(obj.baz);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnion = {

--- a/src/commands/generate/__tests__/resources/test-cases/example-types/product/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-types/product/unionTypeExample.ts
@@ -128,28 +128,16 @@ export interface IUnionTypeExampleVisitor<T> {
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
-    if (isStringExample(obj)) {
-        return visitor.stringExample(obj.stringExample);
+    switch (obj.type) {
+        case "stringExample": return visitor.stringExample(obj.stringExample);
+        case "set": return visitor.set(obj.set);
+        case "thisFieldIsAnInteger": return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
+        case "alsoAnInteger": return visitor.alsoAnInteger(obj.alsoAnInteger);
+        case "if": return visitor.if(obj.if);
+        case "new": return visitor.new(obj.new);
+        case "interface": return visitor.interface(obj.interface);
+        default: return visitor.unknown(obj);
     }
-    if (isSet(obj)) {
-        return visitor.set(obj.set);
-    }
-    if (isThisFieldIsAnInteger(obj)) {
-        return visitor.thisFieldIsAnInteger(obj.thisFieldIsAnInteger);
-    }
-    if (isAlsoAnInteger(obj)) {
-        return visitor.alsoAnInteger(obj.alsoAnInteger);
-    }
-    if (isIf(obj)) {
-        return visitor.if(obj.if);
-    }
-    if (isNew(obj)) {
-        return visitor.new(obj.new);
-    }
-    if (isInterface(obj)) {
-        return visitor.interface(obj.interface);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnionTypeExample = {

--- a/src/commands/generate/__tests__/resources/types/big.ts
+++ b/src/commands/generate/__tests__/resources/types/big.ts
@@ -24,10 +24,10 @@ export interface IBigVisitor<T> {
 }
 
 function visit<T>(obj: IBig, visitor: IBigVisitor<T>): T {
-    if (isLittle(obj)) {
-        return visitor.little(obj.little);
+    switch (obj.type) {
+        case "little": return visitor.little(obj.little);
+        default: return visitor.unknown(obj);
     }
-    return visitor.unknown(obj);
 }
 
 export const IBig = {

--- a/src/commands/generate/__tests__/resources/types/little.ts
+++ b/src/commands/generate/__tests__/resources/types/little.ts
@@ -22,10 +22,10 @@ export interface ILittleVisitor<T> {
 }
 
 function visit<T>(obj: ILittle, visitor: ILittleVisitor<T>): T {
-    if (isDouble(obj)) {
-        return visitor.double(obj.double);
+    switch (obj.type) {
+        case "double": return visitor.double(obj.double);
+        default: return visitor.unknown(obj);
     }
-    return visitor.unknown(obj);
 }
 
 export const ILittle = {

--- a/src/commands/generate/__tests__/resources/types/primitiveUnion.ts
+++ b/src/commands/generate/__tests__/resources/types/primitiveUnion.ts
@@ -56,16 +56,12 @@ export interface IPrimitiveUnionVisitor<T> {
 }
 
 function visit<T>(obj: IPrimitiveUnion, visitor: IPrimitiveUnionVisitor<T>): T {
-    if (isBar(obj)) {
-        return visitor.bar(obj.bar);
+    switch (obj.type) {
+        case "bar": return visitor.bar(obj.bar);
+        case "foo": return visitor.foo(obj.foo);
+        case "uuid": return visitor.uuid(obj.uuid);
+        default: return visitor.unknown(obj);
     }
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
-    }
-    if (isUuid(obj)) {
-        return visitor.uuid(obj.uuid);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IPrimitiveUnion = {

--- a/src/commands/generate/__tests__/resources/types/recursiveUnion.ts
+++ b/src/commands/generate/__tests__/resources/types/recursiveUnion.ts
@@ -41,13 +41,11 @@ export interface IRecursiveUnionVisitor<T> {
 }
 
 function visit<T>(obj: IRecursiveUnion, visitor: IRecursiveUnionVisitor<T>): T {
-    if (isRecursiveField(obj)) {
-        return visitor.recursiveField(obj.recursiveField);
+    switch (obj.type) {
+        case "recursiveField": return visitor.recursiveField(obj.recursiveField);
+        case "stringAlias": return visitor.stringAlias(obj.stringAlias);
+        default: return visitor.unknown(obj);
     }
-    if (isStringAlias(obj)) {
-        return visitor.stringAlias(obj.stringAlias);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IRecursiveUnion = {

--- a/src/commands/generate/__tests__/resources/types/unionTypeExample.ts
+++ b/src/commands/generate/__tests__/resources/types/unionTypeExample.ts
@@ -39,13 +39,11 @@ export interface IUnionTypeExampleVisitor<T> {
 }
 
 function visit<T>(obj: IUnionTypeExample, visitor: IUnionTypeExampleVisitor<T>): T {
-    if (isString(obj)) {
-        return visitor.string(obj.string);
+    switch (obj.type) {
+        case "string": return visitor.string(obj.string);
+        case "set": return visitor.set(obj.set);
+        default: return visitor.unknown(obj);
     }
-    if (isSet(obj)) {
-        return visitor.set(obj.set);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnionTypeExample = {

--- a/src/commands/generate/__tests__/resources/types/unionWithDocs.ts
+++ b/src/commands/generate/__tests__/resources/types/unionWithDocs.ts
@@ -41,13 +41,11 @@ export interface IUnionWithDocsVisitor<T> {
 }
 
 function visit<T>(obj: IUnionWithDocs, visitor: IUnionWithDocsVisitor<T>): T {
-    if (isBar(obj)) {
-        return visitor.bar(obj.bar);
+    switch (obj.type) {
+        case "bar": return visitor.bar(obj.bar);
+        case "foo": return visitor.foo(obj.foo);
+        default: return visitor.unknown(obj);
     }
-    if (isFoo(obj)) {
-        return visitor.foo(obj.foo);
-    }
-    return visitor.unknown(obj);
 }
 
 export const IUnionWithDocs = {

--- a/src/commands/generate/generators/generateType.ts
+++ b/src/commands/generate/generators/generateType.ts
@@ -344,7 +344,7 @@ function processUnionMembers(
     const visitorProperties: PropertySignatureStructure[] = [];
     const memberInterfaces: InterfaceDeclarationStructure[] = [];
     const functions: FunctionDeclarationStructure[] = [];
-    const visitorStatements: string[] = [];
+    const visitorCaseStatements: string[] = [];
 
     definition.union.forEach(fieldDefinition => {
         const memberName = fieldDefinition.fieldName;
@@ -420,9 +420,9 @@ function processUnionMembers(
             type: `(obj: ${fieldType}) => T`,
             isReadonly: typeGenerationFlags.readonlyInterfaces,
         });
-        visitorStatements.push(`if (${typeGuard.name}(${obj})) {
-            return ${visitor}.${memberName}(${obj}.${memberName});
-        }`);
+        visitorCaseStatements.push(
+            `case ${doubleQuote(memberName)}: return ${visitor}.${memberName}(${obj}.${memberName});`,
+        );
     });
 
     visitorProperties.push({
@@ -431,7 +431,16 @@ function processUnionMembers(
         type: `(obj: ${unionTsType}) => T`,
         isReadonly: typeGenerationFlags.readonlyInterfaces,
     });
-    visitorStatements.push(`return ${visitor}.unknown(${obj});`);
+
+    const visitorStatements: string[] = [];
+    if (visitorCaseStatements.length === 0) {
+        visitorStatements.push(`return ${visitor}.unknown(${obj});`);
+    } else {
+        visitorStatements.push(`switch (${obj}.type) {`);
+        visitorStatements.push(...visitorCaseStatements);
+        visitorStatements.push(`default: return ${visitor}.unknown(${obj});`);
+        visitorStatements.push(`}`);
+    }
 
     return {
         functions,


### PR DESCRIPTION
## Before this PR

Benchmarking shows this to be ~1.6x faster:

     10,000,000 values, 50 iterations (10 warmup), 20 union variants

     if-chain     avg=196.9ms  min=192.2ms  max=203.4ms  50,797,962 calls/s
     switch       avg=119.8ms  min=118.3ms  max=121.3ms  83,507,233 calls/s


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

