### PR TITLE
Update CircleCI image to JDK v24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:11-node-browsers
+      - image: cimg/openjdk:24.0-browsers
     steps:
       - checkout
       - restore_cache:

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,11 @@ module.exports = {
             tsconfig: 'src/tsconfig.json',
         },
     },
+    // Jest mistakenly believes it has access to all CPU cores on CI of the
+    // underlying host, rather than the 2 CPU cores allocated to it for
+    // CircleCI's medium resource class. Spawning 32-64 workers causes Jest
+    // tests to hang on CI.
+    maxWorkers: process.env.CI ? 2 : undefined,
     moduleFileExtensions: [
         'js',
         'json',


### PR DESCRIPTION
To support NPM publishing with OIDC (https://github.com/palantir/conjure-typescript/pull/381), we'll need a newer version of Node.js and NPM.