### PR TITLE
Use `registry.npmjs.org` rather than `registry.yarnpkg.com`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.yarnpkg.com
+registry=https://registry.npmjs.org


### PR DESCRIPTION
## Problem

Testing out https://github.com/palantir/conjure-typescript/pull/381 and the build failed with:

https://app.circleci.com/pipelines/github/palantir/conjure-typescript/768/workflows/69ef86dc-3d8d-4cc0-9619-08820239d41d/jobs/1302

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.yarnpkg.com
npm error need auth You need to authorize this machine using `npm adduser`
npm error A complete log of this run can be found in: /home/circleci/.npm/_logs/2026-03-17T02_11_51_667Z-debug-0.log
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Changes

I'm guessing this is because the token obtained in https://github.com/palantir/conjure-typescript/pull/381 is for `registry.npmjs.org` rather than the Yarn registry mirror.

Let's switch the NPM registry in this repo to the official one.