### PR TITLE
Install a newer version of Node.js and NPM on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,18 @@
 # To manually manage the CircleCI configuration for this project, remove the .circleci/template.sh file.
 
 version: 2.1
+
+orbs:
+  node: circleci/node@7.2.1
+
 jobs:
   build:
     docker:
       - image: cimg/openjdk:24.0-browsers
     steps:
       - checkout
+      - node/install:
+          node-version: '25.8.1'
       - restore_cache:
           name: Restore Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # To request a modification to the general template, file an issue on Excavator.
 # To manually manage the CircleCI configuration for this project, remove the .circleci/template.sh file.
 
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -47,7 +47,6 @@ jobs:
         command: echo "All required jobs finished successfully"
 
 workflows:
-  version: 2
   build:
     jobs:
       - build:


### PR DESCRIPTION
## Problem

From https://docs.npmjs.com/trusted-publishers

> [!NOTE]  
> Trusted publishing requires [npm CLI](https://docs.npmjs.com/cli/v11) version 11.5.1 or later and Node version 22.14.0 or higher.

Although https://github.com/palantir/conjure-typescript/pull/382 increased our Node.js and NPM version, it's still not new enough. When SSH'ing into a Circle build, `npm --version` currently reports a 10.x version and we'll need 11.5.1+.

## Changes

Let's use the CircleCI [Node.js orb](https://circleci.com/developer/orbs/orb/circleci/node) to install a newer version of Node.js and NPM.

The [release notes for Node.js 25](https://nodejs.org/en/blog/release/v25.0.0) states that it now includes NPM 11.6.2.