### PR TITLE
Generate `ReadonlyArray<T>` for input parameters list/set types

### DIFF
--- a/src/__tests__/resolveTsTypeTests.ts
+++ b/src/__tests__/resolveTsTypeTests.ts
@@ -167,7 +167,7 @@ describe("resolveTsTypeForListType", () => {
                 DEFAULT_TYPE_GENERATION_FLAGS,
                 true,
             ),
-        ).toEqual("Array<string>");
+        ).toEqual("ReadonlyArray<string>");
     });
 
     it("returns correct type for read-only interfaces generation flag", () => {
@@ -233,7 +233,7 @@ describe("resolveTsTypeForSetType", () => {
                 DEFAULT_TYPE_GENERATION_FLAGS,
                 true,
             ),
-        ).toEqual("Array<string>");
+        ).toEqual("ReadonlyArray<string>");
     });
 
     it("returns correct type for read-only interfaces generation flag", () => {

--- a/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/flavored-test-cases/example-service/another/testService.ts
@@ -34,8 +34,8 @@ export interface ITestService {
     getBranchesDeprecated(datasetRid: string): Promise<Array<string>>;
     resolveBranch(datasetRid: string, branch: string): Promise<string | null>;
     testParam(datasetRid: string): Promise<string | null>;
-    testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
-    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
     testBoolean(): Promise<boolean>;
     testDouble(): Promise<number | "NaN">;
     testInteger(): Promise<number>;
@@ -272,7 +272,7 @@ export class TestService implements ITestService {
         );
     }
 
-    public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
         return this.bridge.call<number>(
             "TestService",
             "testQueryParams",
@@ -293,7 +293,7 @@ export class TestService implements ITestService {
         );
     }
 
-    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
         return this.bridge.call<void>(
             "TestService",
             "testNoResponseQueryParams",

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testService.ts
@@ -33,8 +33,8 @@ export interface ITestService {
     getBranchesDeprecated(datasetRid: string): Promise<Array<string>>;
     resolveBranch(datasetRid: string, branch: string): Promise<string | null>;
     testParam(datasetRid: string): Promise<string | null>;
-    testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
-    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void>;
     testBoolean(): Promise<boolean>;
     testDouble(): Promise<number | "NaN">;
     testInteger(): Promise<number>;
@@ -271,7 +271,7 @@ export class TestService implements ITestService {
         );
     }
 
-    public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<number> {
         return this.bridge.call<number>(
             "TestService",
             "testQueryParams",
@@ -292,7 +292,7 @@ export class TestService implements ITestService {
         );
     }
 
-    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<void> {
         return this.bridge.call<void>(
             "TestService",
             "testNoResponseQueryParams",

--- a/src/commands/generate/__tests__/resources/test-cases/example-service/another/testServiceWithErrors.ts
+++ b/src/commands/generate/__tests__/resources/test-cases/example-service/another/testServiceWithErrors.ts
@@ -36,8 +36,8 @@ export interface ITestServiceWithErrors {
     getBranchesDeprecated(datasetRid: string): Promise<IConjureResult<Array<string>, never>>;
     resolveBranch(datasetRid: string, branch: string): Promise<IConjureResult<string | null, never>>;
     testParam(datasetRid: string): Promise<IConjureResult<string | null, never>>;
-    testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<number, never>>;
-    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<void, never>>;
+    testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<number, never>>;
+    testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<void, never>>;
     testBoolean(): Promise<IConjureResult<boolean, never>>;
     testDouble(): Promise<IConjureResult<number | "NaN", never>>;
     testInteger(): Promise<IConjureResult<number, never>>;
@@ -298,7 +298,7 @@ export class TestServiceWithErrors implements ITestServiceWithErrors {
             .catch((error: any) => ({ status: "failure", error }));
     }
 
-    public testQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<number, never>> {
+    public testQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<number, never>> {
         return this.bridge
             .call<number>(
                 "TestService",
@@ -322,7 +322,7 @@ export class TestServiceWithErrors implements ITestServiceWithErrors {
             .catch((error: any) => ({ status: "failure", error }));
     }
 
-    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: Array<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<void, never>> {
+    public testNoResponseQueryParams(query: string, something: string, implicit: string, setEnd: ReadonlyArray<string>, optionalMiddle?: string | null, optionalEnd?: string | null): Promise<IConjureResult<void, never>> {
         return this.bridge
             .call<void>(
                 "TestService",

--- a/src/utils/resolveTsType.ts
+++ b/src/utils/resolveTsType.ts
@@ -145,7 +145,11 @@ export const resolveTsTypeForListType = (
         isParameterType,
         false,
     );
-    return typeGenerationFlags.readonlyInterfaces ? `ReadonlyArray<${itemType}>` : `Array<${itemType}>`;
+    // Endpoint inputs are emitted as ReadonlyArray to advertise that we won't mutate them, which lets callers pass
+    // either readonly or mutable arrays.
+    return isParameterType || typeGenerationFlags.readonlyInterfaces
+        ? `ReadonlyArray<${itemType}>`
+        : `Array<${itemType}>`;
 };
 
 export const resolveTsTypeForSetType = (
@@ -163,7 +167,9 @@ export const resolveTsTypeForSetType = (
         isParameterType,
         false,
     );
-    return typeGenerationFlags.readonlyInterfaces ? `ReadonlyArray<${itemType}>` : `Array<${itemType}>`;
+    return isParameterType || typeGenerationFlags.readonlyInterfaces
+        ? `ReadonlyArray<${itemType}>`
+        : `Array<${itemType}>`;
 };
 
 export const resolveTsTypeForOptionalType = (

--- a/src/utils/resolveTsType.ts
+++ b/src/utils/resolveTsType.ts
@@ -145,8 +145,7 @@ export const resolveTsTypeForListType = (
         isParameterType,
         false,
     );
-    // Endpoint inputs are emitted as ReadonlyArray to advertise that we won't mutate them, which lets callers pass
-    // either readonly or mutable arrays.
+    // Inputs are emitted as ReadonlyArray to widen the contract & guarantee to callers that we won't mutate them
     return isParameterType || typeGenerationFlags.readonlyInterfaces
         ? `ReadonlyArray<${itemType}>`
         : `Array<${itemType}>`;


### PR DESCRIPTION
Methods now declare `list` and `set` types as `ReadonlyArray<T>` (when they're used as input via `isParameterType`) to advertise that we don't mutate inputs. 


This is not a break, and not a change to `readonlyInterfaces`, since it widens the contract (`Array<T>` is assignable to `ReadonlyArray<T>`)