### PR TITLE
Port conjure-core IR validators to TypeScript for input validation before code generation

### DIFF
--- a/src/__tests__/conjureValidatorTests.ts
+++ b/src/__tests__/conjureValidatorTests.ts
@@ -1,0 +1,1310 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IConjureDefinition } from "conjure-api";
+import { validateConjureDefinition } from "../utils/conjureValidator";
+import {
+    convertToCamelCase,
+    matchesCamelCase,
+    matchesKebabCase,
+    matchesSnakeCase,
+} from "../utils/validators/fieldNameValidator";
+
+function makeDef(overrides: Partial<IConjureDefinition> = {}): IConjureDefinition {
+    const base = { version: 1, errors: [], services: [], types: [], ...overrides };
+    return base as IConjureDefinition;
+}
+
+function makeAlias(name: string, pkg: string): any {
+    return {
+        type: "alias",
+        alias: {
+            typeName: { name, package: pkg },
+            alias: { type: "primitive", primitive: "STRING" },
+        },
+    };
+}
+
+function makeObject(name: string, pkg: string, fields: any[]): any {
+    return {
+        type: "object",
+        object: { typeName: { name, package: pkg }, fields },
+    };
+}
+
+function makeEnum(name: string, pkg: string, values: string[]): any {
+    return {
+        type: "enum",
+        enum: {
+            typeName: { name, package: pkg },
+            values: values.map(v => ({ value: v })),
+        },
+    };
+}
+
+function makeUnion(name: string, pkg: string, members: any[]): any {
+    return {
+        type: "union",
+        union: {
+            typeName: { name, package: pkg },
+            union: members,
+        },
+    };
+}
+
+function makeService(name: string, pkg: string, endpoints: any[]): any {
+    return {
+        serviceName: { name, package: pkg },
+        endpoints,
+    };
+}
+
+function makeEndpoint(name: string, method: string, path: string, args: any[] = []): any {
+    return { endpointName: name, httpMethod: method, httpPath: path, args };
+}
+
+function makeError(
+    name: string,
+    pkg: string,
+    namespace: string,
+    code: string,
+    safeArgs: any[] = [],
+    unsafeArgs: any[] = [],
+): any {
+    return {
+        errorName: { name, package: pkg },
+        namespace,
+        code,
+        safeArgs,
+        unsafeArgs,
+    };
+}
+
+function field(name: string, type: any = { type: "primitive", primitive: "STRING" }): any {
+    return { fieldName: name, type };
+}
+
+// --- Case pattern tests ---
+
+describe("matchesCamelCase", () => {
+    it("accepts valid camelCase", () => {
+        expect(matchesCamelCase("myVar")).toBe(true);
+        expect(matchesCamelCase("myVarName")).toBe(true);
+        expect(matchesCamelCase("a")).toBe(true);
+        expect(matchesCamelCase("ab")).toBe(true);
+        expect(matchesCamelCase("myVarX")).toBe(true); // trailing single uppercase ok
+    });
+
+    it("rejects invalid camelCase", () => {
+        expect(matchesCamelCase("MyVar")).toBe(false); // starts with uppercase
+        expect(matchesCamelCase("myVARName")).toBe(false); // 3+ consecutive uppercase
+        expect(matchesCamelCase("my-var")).toBe(false); // contains dash
+        expect(matchesCamelCase("my_var")).toBe(false); // contains underscore
+        expect(matchesCamelCase("")).toBe(false);
+    });
+});
+
+describe("matchesKebabCase", () => {
+    it("accepts valid kebab-case", () => {
+        expect(matchesKebabCase("my-var")).toBe(true);
+        expect(matchesKebabCase("my-var-name")).toBe(true);
+        expect(matchesKebabCase("a")).toBe(true);
+    });
+
+    it("rejects invalid kebab-case", () => {
+        expect(matchesKebabCase("my--var")).toBe(false); // double dash
+        expect(matchesKebabCase("My-Var")).toBe(false); // uppercase
+        expect(matchesKebabCase("-var")).toBe(false); // starts with dash
+        expect(matchesKebabCase("")).toBe(false);
+    });
+});
+
+describe("matchesSnakeCase", () => {
+    it("accepts valid snake_case", () => {
+        expect(matchesSnakeCase("my_var")).toBe(true);
+        expect(matchesSnakeCase("my_var_name")).toBe(true);
+        expect(matchesSnakeCase("a")).toBe(true);
+    });
+
+    it("rejects invalid snake_case", () => {
+        expect(matchesSnakeCase("my__var")).toBe(false); // double underscore
+        expect(matchesSnakeCase("My_Var")).toBe(false); // uppercase
+        expect(matchesSnakeCase("_var")).toBe(false); // starts with underscore
+        expect(matchesSnakeCase("")).toBe(false);
+    });
+});
+
+describe("convertToCamelCase", () => {
+    it("converts kebab to camel", () => {
+        expect(convertToCamelCase("my-var")).toBe("myVar");
+        expect(convertToCamelCase("field-name-with-dashes")).toBe("fieldNameWithDashes");
+    });
+
+    it("converts snake to camel", () => {
+        expect(convertToCamelCase("my_var")).toBe("myVar");
+    });
+
+    it("returns camelCase unchanged", () => {
+        expect(convertToCamelCase("myVar")).toBe("myVar");
+    });
+});
+
+// --- Top-level orchestrator tests ---
+
+describe("validateConjureDefinition", () => {
+    describe("type names (PascalCase)", () => {
+        it("accepts valid PascalCase", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("MyAlias", "com.palantir.product")],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects lowercase start", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("myAlias", "com.palantir.product")],
+                    }),
+                ),
+            ).toThrow(/TypeNames must/);
+        });
+
+        it("rejects consecutive uppercase", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("HTTPRequest", "com.palantir.product")],
+                    }),
+                ),
+            ).toThrow(/TypeNames must/);
+        });
+
+        it("rejects injection payload in name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias('Evil"Name', "com.palantir.product")],
+                    }),
+                ),
+            ).toThrow(/TypeNames must/);
+        });
+    });
+
+    describe("package names", () => {
+        it("accepts valid package", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("MyAlias", "com.palantir.product")],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts empty package", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("MyAlias", "")],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects uppercase in package", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("MyAlias", "Com.Palantir")],
+                    }),
+                ),
+            ).toThrow(/package names must match/);
+        });
+
+        it("rejects injection in package", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("MyAlias", 'com.evil";\nexport const x = 1;\n//x')],
+                    }),
+                ),
+            ).toThrow(/package names must match/);
+        });
+    });
+
+    describe("enum values", () => {
+        it("accepts SCREAMING_SNAKE_CASE", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeEnum("MyEnum", "com.palantir.product", ["MY_VALUE", "ANOTHER"])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects lowercase enum value", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeEnum("MyEnum", "com.palantir.product", ["lowercase"])],
+                    }),
+                ),
+            ).toThrow(/Enumeration values must match/);
+        });
+
+        it("rejects reserved UNKNOWN (case insensitive)", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeEnum("MyEnum", "com.palantir.product", ["UNKNOWN"])],
+                    }),
+                ),
+            ).toThrow(/UNKNOWN is a reserved/);
+        });
+
+        it("rejects duplicate enum values", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeEnum("MyEnum", "com.palantir.product", ["VALUE", "VALUE"])],
+                    }),
+                ),
+            ).toThrow(/duplicate enum values/);
+        });
+    });
+
+    describe("object field names", () => {
+        it("accepts camelCase", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field("myField")])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts kebab-case (legacy)", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field("my-field")])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts snake_case (legacy)", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field("my_field")])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects injection in field name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field('x"; malicious()')])],
+                    }),
+                ),
+            ).toThrow(/FieldName/);
+        });
+
+        it("rejects duplicate field names after normalization", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field("myField"), field("my-field")])],
+                    }),
+                ),
+            ).toThrow(/duplicate field names/);
+        });
+    });
+
+    describe("union members", () => {
+        it("accepts valid union member", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeUnion("MyUnion", "com.palantir.product", [field("myMember")])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects 'type' as union member", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeUnion("MyUnion", "com.palantir.product", [field("type")])],
+                    }),
+                ),
+            ).toThrow(/must not be 'type'/);
+        });
+
+        it("rejects trailing underscore", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeUnion("MyUnion", "com.palantir.product", [field("trailingValue_")])],
+                    }),
+                ),
+            ).toThrow(/FieldName/);
+        });
+
+        it("rejects invalid union member field name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeUnion("MyUnion", "com.palantir.product", [field('bad"name')])],
+                    }),
+                ),
+            ).toThrow(/FieldName/);
+        });
+
+        it("accepts reserved words as union members (valid Java identifiers)", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeUnion("MyUnion", "com.palantir.product", [field("if"), field("new")])],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+    });
+
+    describe("unique names", () => {
+        it("rejects duplicate type names", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeAlias("MyAlias", "com.palantir.product"),
+                            makeAlias("MyAlias", "com.palantir.product"),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Duplicate/i);
+        });
+
+        it("rejects duplicate service names", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", []),
+                            makeService("MyService", "com.palantir.product", []),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Duplicate/i);
+        });
+
+        it("rejects type and error with same name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("Collision", "com.palantir.product")],
+                        errors: [makeError("Collision", "com.palantir.product", "Conjure", "INTERNAL")],
+                    }),
+                ),
+            ).toThrow(/Duplicate type\/error\/service name/);
+        });
+
+        it("rejects type and service with same name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeAlias("Collision", "com.palantir.product")],
+                        services: [makeService("Collision", "com.palantir.product", [])],
+                    }),
+                ),
+            ).toThrow(/Duplicate type\/error\/service name/);
+        });
+
+        it("rejects duplicate error names within same namespace", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [
+                            makeError("MyError", "com.palantir.a", "Conjure", "INTERNAL"),
+                            makeError("MyError", "com.palantir.b", "Conjure", "NOT_FOUND"),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Duplicate error name/);
+        });
+    });
+
+    describe("services", () => {
+        it("accepts valid service", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects service name ending in Retrofit", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [makeService("MyServiceRetrofit", "com.palantir.product", [])],
+                    }),
+                ),
+            ).toThrow(/Retrofit/);
+        });
+
+        it("rejects duplicate path+method", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items"),
+                                makeEndpoint("listItems", "GET", "/items"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/defined by multiple endpoints/);
+        });
+    });
+
+    describe("endpoints", () => {
+        it("rejects non-camelCase endpoint name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("GetItems", "GET", "/items"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Endpoint names must be camelCase/);
+        });
+
+        it("rejects injection in endpoint name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint('foo(){require("child_process")}//', "GET", "/items"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Endpoint names must be camelCase/);
+        });
+
+        it("rejects non-camelCase parameter name", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "BadName",
+                                        paramType: { type: "query", query: { paramId: "badName" } },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/camelCase/);
+        });
+
+        it("rejects multiple body params", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("create", "POST", "/items", [
+                                    {
+                                        argName: "body1",
+                                        paramType: { type: "body" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                    {
+                                        argName: "body2",
+                                        paramType: { type: "body" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/multiple body parameters/);
+        });
+
+        it("rejects GET with body", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "body1",
+                                        paramType: { type: "body" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/GET and contain a body/);
+        });
+
+        it("validates header paramId format", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "authToken",
+                                        paramType: { type: "header", header: { paramId: "X-Auth-Token" } },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects reserved protocol header paramId", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "contentType",
+                                        paramType: { type: "header", header: { paramId: "Content-Type" } },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/protocol headers/);
+        });
+
+        it("rejects path params not matching template", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId}", [
+                                    {
+                                        argName: "wrongName",
+                                        paramType: { type: "path" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/path template/);
+        });
+    });
+
+    describe("HTTP paths", () => {
+        it("rejects path not starting with /", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "items"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/start with/);
+        });
+
+        it("rejects path ending with /", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items/"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/not end with/);
+        });
+
+        it("rejects injection in path", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", '/items";require("child_process")'),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/did not match/);
+        });
+    });
+
+    describe("error definitions", () => {
+        it("accepts valid error", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [makeError("MyError", "com.palantir.product", "Conjure", "INVALID_ARGUMENT")],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects invalid error code", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [makeError("MyError", "com.palantir.product", "Conjure", "MADE_UP")],
+                    }),
+                ),
+            ).toThrow(/Invalid error code/);
+        });
+
+        it("rejects invalid namespace", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [makeError("MyError", "com.palantir.product", "bad_namespace", "INTERNAL")],
+                    }),
+                ),
+            ).toThrow(/Namespace for errors/);
+        });
+
+        it("rejects injection in namespace", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [makeError("MyError", "com.palantir.product", 'Evil";\nprocess.exit(1)//', "INTERNAL")],
+                    }),
+                ),
+            ).toThrow(/Namespace for errors/);
+        });
+
+        it("validates error arg field names", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [
+                            makeError("MyError", "com.palantir.product", "Conjure", "INTERNAL", [
+                                field('"; inject()//'),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/FieldName/);
+        });
+
+        it("rejects duplicate error arg names after normalization", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [
+                            makeError(
+                                "MyError",
+                                "com.palantir.product",
+                                "Conjure",
+                                "INTERNAL",
+                                [field("myField")],
+                                [field("my-field")],
+                            ),
+                        ],
+                    }),
+                ),
+            ).toThrow(/duplicate field names/);
+        });
+    });
+
+    describe("recursive types", () => {
+        it("rejects direct self-reference via alias", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "SelfRef", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "reference",
+                                        reference: { name: "SelfRef", package: "com.palantir.product" },
+                                    },
+                                },
+                            } as any,
+                        ],
+                    }),
+                ),
+            ).toThrow(/Recursive types/);
+        });
+    });
+
+    describe("nested optionals", () => {
+        it("rejects optional of alias to optional", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "OptAlias", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "optional",
+                                        optional: { itemType: { type: "primitive", primitive: "STRING" } },
+                                    },
+                                },
+                            } as any,
+                            makeObject("MyObj", "com.palantir.product", [
+                                field("bad", {
+                                    type: "optional",
+                                    optional: {
+                                        itemType: {
+                                            type: "reference",
+                                            reference: { name: "OptAlias", package: "com.palantir.product" },
+                                        },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Nested optionals/);
+        });
+    });
+
+    describe("illegal map keys", () => {
+        it("rejects complex map key in object field", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeObject("MyObj", "com.palantir.product", [
+                                field("bad", {
+                                    type: "map",
+                                    map: {
+                                        keyType: {
+                                            type: "list",
+                                            list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                        },
+                                        valueType: { type: "primitive", primitive: "STRING" },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Complex type not allowed in map key/);
+        });
+
+        it("rejects complex map key in union member", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeUnion("MyUnion", "com.palantir.product", [
+                                field("bad", {
+                                    type: "map",
+                                    map: {
+                                        keyType: {
+                                            type: "list",
+                                            list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                        },
+                                        valueType: { type: "primitive", primitive: "STRING" },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Complex type not allowed in map key/);
+        });
+
+        it("rejects complex map key in alias", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "BadAlias", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "map",
+                                        map: {
+                                            keyType: {
+                                                type: "list",
+                                                list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                            },
+                                            valueType: { type: "primitive", primitive: "STRING" },
+                                        },
+                                    },
+                                },
+                            } as any,
+                        ],
+                    }),
+                ),
+            ).toThrow(/Complex type not allowed in map key/);
+        });
+    });
+
+    describe("endpoint type validators", () => {
+        it("rejects binary in non-body param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "file",
+                                        paramType: { type: "query", query: { paramId: "file" } },
+                                        type: { type: "primitive", primitive: "BINARY" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/binary.*any/i);
+        });
+
+        it("rejects bearer token in query param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "auth",
+                                        paramType: { type: "query", query: { paramId: "auth" } },
+                                        type: { type: "primitive", primitive: "BEARERTOKEN" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/bearertoken.*not allowed/i);
+        });
+
+        it("rejects complex path param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [makeObject("MyObj", "com.palantir.product", [field("name")])],
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId}", [
+                                    {
+                                        argName: "itemId",
+                                        paramType: { type: "path" },
+                                        type: {
+                                            type: "reference",
+                                            reference: { name: "MyObj", package: "com.palantir.product" },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Path parameters must be primitives/);
+        });
+
+        it("rejects list in header param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "tags",
+                                        paramType: { type: "header", header: { paramId: "X-Tags" } },
+                                        type: {
+                                            type: "list",
+                                            list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/header param.*must be/i);
+        });
+
+        it("accepts alias to optional<string> in header param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "OptString", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "optional",
+                                        optional: { itemType: { type: "primitive", primitive: "STRING" } },
+                                    },
+                                },
+                            } as any,
+                        ],
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "token",
+                                        paramType: { type: "header", header: { paramId: "X-Token" } },
+                                        type: {
+                                            type: "reference",
+                                            reference: { name: "OptString", package: "com.palantir.product" },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts alias to list<string> in query param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "StringList", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "list",
+                                        list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                    },
+                                },
+                            } as any,
+                        ],
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "tags",
+                                        paramType: { type: "query", query: { paramId: "tags" } },
+                                        type: {
+                                            type: "reference",
+                                            reference: { name: "StringList", package: "com.palantir.product" },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects ANY type in non-body param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "filter",
+                                        paramType: { type: "query", query: { paramId: "filter" } },
+                                        type: { type: "primitive", primitive: "ANY" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/binary.*any/i);
+        });
+
+        it("accepts set<string> in query param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "tags",
+                                        paramType: { type: "query", query: { paramId: "tags" } },
+                                        type: {
+                                            type: "set",
+                                            set: { itemType: { type: "primitive", primitive: "STRING" } },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects map in query param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items", [
+                                    {
+                                        argName: "filters",
+                                        paramType: { type: "query", query: { paramId: "filters" } },
+                                        type: {
+                                            type: "map",
+                                            map: {
+                                                keyType: { type: "primitive", primitive: "STRING" },
+                                                valueType: { type: "primitive", primitive: "STRING" },
+                                            },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/query param.*must be/i);
+        });
+
+        it("rejects optional binary body", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("upload", "POST", "/upload", [
+                                    {
+                                        argName: "data",
+                                        paramType: { type: "body" },
+                                        type: {
+                                            type: "optional",
+                                            optional: { itemType: { type: "primitive", primitive: "BINARY" } },
+                                        },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/optional.*binary/i);
+        });
+
+        it("rejects UNKNOWN http method", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("doThing", "UNKNOWN", "/things"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/must not be UNKNOWN/);
+        });
+
+        it("rejects duplicate endpoint errors", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                {
+                                    endpointName: "getItems",
+                                    httpMethod: "GET",
+                                    httpPath: "/items",
+                                    args: [],
+                                    errors: [
+                                        { error: { name: "NotFound", package: "com.palantir", namespace: "Conjure" } },
+                                        { error: { name: "NotFound", package: "com.palantir", namespace: "Conjure" } },
+                                    ],
+                                },
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/declared multiple times/);
+        });
+    });
+
+    describe("HTTP path edge cases", () => {
+        it("accepts path with regex param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId:.+}", [
+                                    {
+                                        argName: "itemId",
+                                        paramType: { type: "path" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("rejects .* regex in non-last segment", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId:.*}/details", [
+                                    {
+                                        argName: "itemId",
+                                        paramType: { type: "path" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/only permitted in the last segment/);
+        });
+
+        it("rejects duplicate path param names", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId}/sub/{itemId}", [
+                                    {
+                                        argName: "itemId",
+                                        paramType: { type: "path" },
+                                        type: { type: "primitive", primitive: "STRING" },
+                                    },
+                                ]),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/appears more than once/);
+        });
+
+        it("rejects path template var without matching endpoint param", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItem", "GET", "/items/{itemId}"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/defined in path template but not present in endpoint/);
+        });
+
+        it("rejects invalid segment characters", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        services: [
+                            makeService("MyService", "com.palantir.product", [
+                                makeEndpoint("getItems", "GET", "/items/foo@bar"),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/did not match/);
+        });
+    });
+
+    describe("error safety declarations", () => {
+        it("rejects error args with explicit safety", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        errors: [
+                            makeError("MyError", "com.palantir.product", "Conjure", "INTERNAL", [
+                                {
+                                    fieldName: "message",
+                                    type: { type: "primitive", primitive: "STRING" },
+                                    safety: "SAFE",
+                                },
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/safety cannot be declared/);
+        });
+    });
+
+    it("accepts empty definition", () => {
+        expect(() => validateConjureDefinition(makeDef())).not.toThrow();
+    });
+});

--- a/src/__tests__/conjureValidatorTests.ts
+++ b/src/__tests__/conjureValidatorTests.ts
@@ -16,8 +16,8 @@
  */
 
 import { IConjureDefinition } from "conjure-api";
-import { sanitizeDocs } from "../utils/docsUtils";
 import { validateConjureDefinition } from "../utils/conjureValidator";
+import { sanitizeDocs } from "../utils/docsUtils";
 import {
     convertToCamelCase,
     matchesCamelCase,

--- a/src/__tests__/conjureValidatorTests.ts
+++ b/src/__tests__/conjureValidatorTests.ts
@@ -16,6 +16,7 @@
  */
 
 import { IConjureDefinition } from "conjure-api";
+import { sanitizeDocs } from "../utils/docsUtils";
 import { validateConjureDefinition } from "../utils/conjureValidator";
 import {
     convertToCamelCase,
@@ -795,6 +796,95 @@ describe("validateConjureDefinition", () => {
                 ),
             ).toThrow(/Recursive types/);
         });
+
+        it("accepts container-wrapped self-reference (Tree with List<Tree>)", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeObject("Tree", "com.palantir.product", [
+                                field("children", {
+                                    type: "list",
+                                    list: {
+                                        itemType: {
+                                            type: "reference",
+                                            reference: { name: "Tree", package: "com.palantir.product" },
+                                        },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts optional self-reference", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeObject("Node", "com.palantir.product", [
+                                field("next", {
+                                    type: "optional",
+                                    optional: {
+                                        itemType: {
+                                            type: "reference",
+                                            reference: { name: "Node", package: "com.palantir.product" },
+                                        },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts set self-reference", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeObject("Graph", "com.palantir.product", [
+                                field("neighbors", {
+                                    type: "set",
+                                    set: {
+                                        itemType: {
+                                            type: "reference",
+                                            reference: { name: "Graph", package: "com.palantir.product" },
+                                        },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
+
+        it("accepts map value self-reference", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            makeObject("Index", "com.palantir.product", [
+                                field("entries", {
+                                    type: "map",
+                                    map: {
+                                        keyType: { type: "primitive", primitive: "STRING" },
+                                        valueType: {
+                                            type: "reference",
+                                            reference: { name: "Index", package: "com.palantir.product" },
+                                        },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).not.toThrow();
+        });
     });
 
     describe("nested optionals", () => {
@@ -867,6 +957,39 @@ describe("validateConjureDefinition", () => {
                                         keyType: {
                                             type: "list",
                                             list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                        },
+                                        valueType: { type: "primitive", primitive: "STRING" },
+                                    },
+                                }),
+                            ]),
+                        ],
+                    }),
+                ),
+            ).toThrow(/Complex type not allowed in map key/);
+        });
+
+        it("rejects map key that is an alias to a container type", () => {
+            expect(() =>
+                validateConjureDefinition(
+                    makeDef({
+                        types: [
+                            {
+                                type: "alias",
+                                alias: {
+                                    typeName: { name: "StringList", package: "com.palantir.product" },
+                                    alias: {
+                                        type: "list",
+                                        list: { itemType: { type: "primitive", primitive: "STRING" } },
+                                    },
+                                },
+                            } as any,
+                            makeObject("MyObj", "com.palantir.product", [
+                                field("bad", {
+                                    type: "map",
+                                    map: {
+                                        keyType: {
+                                            type: "reference",
+                                            reference: { name: "StringList", package: "com.palantir.product" },
                                         },
                                         valueType: { type: "primitive", primitive: "STRING" },
                                     },
@@ -1301,6 +1424,36 @@ describe("validateConjureDefinition", () => {
                     }),
                 ),
             ).toThrow(/safety cannot be declared/);
+        });
+    });
+
+    describe("docs sanitization", () => {
+        it("neutralizes JSDoc breakout payload in docs", () => {
+            const maliciousPayload = "*/;require('child_process').execSync('touch /tmp/PWNED');/*";
+            const sanitized = sanitizeDocs(maliciousPayload);
+            expect(sanitized).not.toContain("*/");
+        });
+
+        it("preserves normal docs content", () => {
+            const normalDocs = "This is a normal documentation string.";
+            expect(sanitizeDocs(normalDocs)).toBe(normalDocs);
+        });
+
+        it("handles docs with asterisks that are not breakouts", () => {
+            const docs = "Returns a * b multiplied values";
+            expect(sanitizeDocs(docs)).toBe(docs);
+        });
+
+        it("handles multiple breakout attempts", () => {
+            const docs = "*/alert(1)/* and also */alert(2)/*";
+            const sanitized = sanitizeDocs(docs);
+            expect(sanitized).not.toContain("*/");
+        });
+
+        it("neutralizes breakout in deprecated field", () => {
+            const maliciousDeprecated = "*/;require('child_process').execSync('touch /tmp/PWNED');/*";
+            const sanitized = sanitizeDocs(maliciousDeprecated);
+            expect(sanitized).not.toContain("*/");
         });
     });
 

--- a/src/__tests__/quotesUtilsTests.ts
+++ b/src/__tests__/quotesUtilsTests.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { doubleQuote, singleQuote } from "../utils/quotesUtils";
+
+describe("doubleQuote", () => {
+    it("wraps simple string", () => {
+        expect(doubleQuote("hello")).toBe('"hello"');
+    });
+
+    it("escapes embedded double quotes", () => {
+        expect(doubleQuote('hello"world')).toBe('"hello\\"world"');
+    });
+
+    it("escapes backslashes before quotes", () => {
+        expect(doubleQuote('hello\\"world')).toBe('"hello\\\\\\"world"');
+    });
+});
+
+describe("singleQuote", () => {
+    it("wraps simple string", () => {
+        expect(singleQuote("hello")).toBe("'hello'");
+    });
+
+    it("escapes embedded single quotes", () => {
+        expect(singleQuote("hello'world")).toBe("'hello\\'world'");
+    });
+
+    it("escapes backslashes before quotes", () => {
+        expect(singleQuote("hello\\'world")).toBe("'hello\\\\\\'world'");
+    });
+});

--- a/src/commands/generate/command.ts
+++ b/src/commands/generate/command.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import { SlsVersion, SlsVersionMatcher } from "sls-version";
 import { Argv, CommandModule } from "yargs";
 import { IPackageJson, IProductDependency, ISlsManifestDependency } from "../../types";
+import { validateConjureDefinition } from "../../utils/conjureValidator";
 import { writeJson } from "../../utils/writeJson";
 import { generate } from "./generator";
 
@@ -208,7 +209,14 @@ export class GenerateCommand implements CommandModule {
 }
 
 export async function loadConjureDefinition(input: string): Promise<IConjureDefinition> {
-    return { errors: [], services: [], types: [], ...JSON.parse(await fs.readFile(input, "utf8")) };
+    const definition: IConjureDefinition = {
+        errors: [],
+        services: [],
+        types: [],
+        ...JSON.parse(await fs.readFile(input, "utf8")),
+    };
+    validateConjureDefinition(definition);
+    return definition;
 }
 
 export async function createPackageJson(

--- a/src/commands/generate/generators/generateNonThrowingService.ts
+++ b/src/commands/generate/generators/generateNonThrowingService.ts
@@ -28,7 +28,7 @@ import {
 } from "ts-morph";
 import { ITypeGenerationFlags } from "../../../types/typeGenerationFlags";
 import { CONJURE_CLIENT_MODULE_SPECIFIER } from "../../../utils/constants";
-import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingToDocs } from "../../../utils/docsUtils";
+import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingToDocs, sanitizeDocs } from "../../../utils/docsUtils";
 import { resolveImports, resolveImportsForReferenceType, sortImports } from "../../../utils/resolveImports";
 import { resolveMediaType } from "../../../utils/resolveMediaType";
 import { resolveTsType } from "../../../utils/resolveTsType";
@@ -183,7 +183,7 @@ export function generateNonThrowingService(
         name: `I${serviceName}`,
     });
     if (definition.docs != null) {
-        iface.addJsDoc({ description: definition.docs });
+        iface.addJsDoc({ description: sanitizeDocs(definition.docs) });
     }
 
     sourceFile.addClass({

--- a/src/commands/generate/generators/generateThrowingService.ts
+++ b/src/commands/generate/generators/generateThrowingService.ts
@@ -27,7 +27,7 @@ import {
 } from "ts-morph";
 import { ITypeGenerationFlags } from "../../../types/typeGenerationFlags";
 import { CONJURE_CLIENT_MODULE_SPECIFIER } from "../../../utils/constants";
-import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingToDocs } from "../../../utils/docsUtils";
+import { addDeprecatedToDocs, addErrorsToDocs, addIncubatingToDocs, sanitizeDocs } from "../../../utils/docsUtils";
 import { resolveImports, resolveImportsForReferenceType, sortImports } from "../../../utils/resolveImports";
 import { resolveTsType } from "../../../utils/resolveTsType";
 import { SimpleAst } from "../simpleAst";
@@ -149,7 +149,7 @@ export function generateThrowingService(
         name: "I" + definition.serviceName.name,
     });
     if (definition.docs != null) {
-        iface.addJsDoc({ description: definition.docs });
+        iface.addJsDoc({ description: sanitizeDocs(definition.docs) });
     }
 
     sourceFile.addClass({

--- a/src/commands/generate/generators/generateType.ts
+++ b/src/commands/generate/generators/generateType.ts
@@ -411,7 +411,10 @@ function processUnionMembers(
             ],
             returnType: interfaceName,
             // deprecate creation of deprecated types
-            docs: fieldDefinition.deprecated != null ? [`@deprecated ${sanitizeDocs(fieldDefinition.deprecated)}`] : undefined,
+            docs:
+                fieldDefinition.deprecated != null
+                    ? [`@deprecated ${sanitizeDocs(fieldDefinition.deprecated)}`]
+                    : undefined,
         });
 
         visitorProperties.push({

--- a/src/commands/generate/generators/generateType.ts
+++ b/src/commands/generate/generators/generateType.ts
@@ -35,7 +35,7 @@ import {
     VariableStatementStructure,
 } from "ts-morph";
 import { ITypeGenerationFlags } from "../../../types/typeGenerationFlags";
-import { addDeprecatedToDocs } from "../../../utils/docsUtils";
+import { addDeprecatedToDocs, sanitizeDocs } from "../../../utils/docsUtils";
 import { isFlavorizable } from "../../../utils/flavorizingUtils";
 import { isValidFunctionName } from "../../../utils/functionUtils";
 import { doubleQuote, singleQuote } from "../../../utils/quotesUtils";
@@ -101,7 +101,7 @@ export async function generateAlias(
             ].join("\n"),
         });
         if (definition.docs) {
-            typeAlias.addJsDoc(definition.docs);
+            typeAlias.addJsDoc(sanitizeDocs(definition.docs));
         }
         sourceFile.formatText();
         return sourceFile.save();
@@ -159,7 +159,7 @@ export async function generateEnum(definition: IEnumDefinition, simpleAst: Simpl
             statements: [...typeAliases, ...variableDeclarations],
         });
         if (definition.docs != null) {
-            namespaceDefinition.addJsDoc(definition.docs);
+            namespaceDefinition.addJsDoc(sanitizeDocs(definition.docs));
         }
         sourceFile.addTypeAlias({
             isExported: true,
@@ -181,7 +181,7 @@ export async function generateEnum(definition: IEnumDefinition, simpleAst: Simpl
             isExported: true,
         });
         if (definition.docs != null) {
-            variableStatement.addJsDoc(definition.docs);
+            variableStatement.addJsDoc(sanitizeDocs(definition.docs));
         }
         sourceFile.addTypeAlias({
             isExported: true,
@@ -247,8 +247,8 @@ export async function generateObject(
         name: "I" + definition.typeName.name,
         properties,
     });
-    if (definition.docs != null && definition.docs != null) {
-        iface.addJsDoc({ description: definition.docs });
+    if (definition.docs != null) {
+        iface.addJsDoc({ description: sanitizeDocs(definition.docs) });
     }
 
     sourceFile.formatText();
@@ -277,7 +277,7 @@ export async function generateUnion(
     sourceFile.addFunctions(unionSourceFileInput.functions);
 
     sourceFile.addTypeAlias({
-        docs: definition.docs != null ? [{ description: definition.docs }] : undefined,
+        docs: definition.docs != null ? [{ description: sanitizeDocs(definition.docs) }] : undefined,
         isExported: true,
         name: unionTsType,
         type:
@@ -411,7 +411,7 @@ function processUnionMembers(
             ],
             returnType: interfaceName,
             // deprecate creation of deprecated types
-            docs: fieldDefinition.deprecated != null ? [`@deprecated ${fieldDefinition.deprecated}`] : undefined,
+            docs: fieldDefinition.deprecated != null ? [`@deprecated ${sanitizeDocs(fieldDefinition.deprecated)}`] : undefined,
         });
 
         visitorProperties.push({

--- a/src/utils/conjureValidator.ts
+++ b/src/utils/conjureValidator.ts
@@ -92,7 +92,7 @@ function validateUniqueErrorNames(definition: IConjureDefinition): void {
     }
 }
 
-// Compute knownTypes map (same as generator.ts:105-135 but without error types for validation)
+// Compute knownTypes map (same as computeKnownTypes in generator.ts but without error types)
 function computeKnownTypes(definition: IConjureDefinition): Map<string, ITypeDefinition> {
     const knownTypes = new Map<string, ITypeDefinition>();
 

--- a/src/utils/conjureValidator.ts
+++ b/src/utils/conjureValidator.ts
@@ -18,10 +18,13 @@
 // Direct port of conjure-core ConjureDefinitionValidator.validateAll()
 // Orchestrates all validators in the same order as the Java implementation.
 //
-// Note: Both this implementation and the Java original are susceptible to JSDoc
-// injection via `docs` fields (e.g., docs: "*/ malicious /*"). This has been
-// deemed low risk since JSDoc comments are stripped by tsc and cannot produce
-// executable code in the emitted JavaScript.
+// Note: Neither this implementation nor the Java original validates `docs` fields,
+// which could contain JSDoc breakout payloads (e.g., docs: "*/ malicious code /*").
+// This is not exploitable in conjure-typescript because ts-morph's AST manipulation
+// rejects the malformed output (throws ManipulationError or NotImplementedError)
+// before any file is written. Field/method-level docs land inside interface bodies
+// where executable code is not valid TypeScript. This does NOT hold for all Conjure
+// generators — e.g., conjure-go emits comments as raw text without AST validation.
 
 import { IConjureDefinition, ITypeDefinition } from "conjure-api";
 import { createHashableTypeName } from "./hashingUtils";

--- a/src/utils/conjureValidator.ts
+++ b/src/utils/conjureValidator.ts
@@ -18,13 +18,10 @@
 // Direct port of conjure-core ConjureDefinitionValidator.validateAll()
 // Orchestrates all validators in the same order as the Java implementation.
 //
-// Note: Neither this implementation nor the Java original validates `docs` fields,
-// which could contain JSDoc breakout payloads (e.g., docs: "*/ malicious code /*").
-// This is not exploitable in conjure-typescript because ts-morph's AST manipulation
-// rejects the malformed output (throws ManipulationError or NotImplementedError)
-// before any file is written. Field/method-level docs land inside interface bodies
-// where executable code is not valid TypeScript. This does NOT hold for all Conjure
-// generators — e.g., conjure-go emits comments as raw text without AST validation.
+// Note: Neither this implementation nor the Java original validates `docs` fields.
+// JSDoc breakout payloads (e.g., docs: "*/ malicious code /*") are neutralized
+// by sanitizeDocs() in docsUtils.ts, which is applied at every point where IR
+// strings enter generated JSDoc comments.
 
 import { IConjureDefinition, ITypeDefinition } from "conjure-api";
 import { createHashableTypeName } from "./hashingUtils";

--- a/src/utils/conjureValidator.ts
+++ b/src/utils/conjureValidator.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core ConjureDefinitionValidator.validateAll()
+// Orchestrates all validators in the same order as the Java implementation.
+//
+// Note: Both this implementation and the Java original are susceptible to JSDoc
+// injection via `docs` fields (e.g., docs: "*/ malicious /*"). This has been
+// deemed low risk since JSDoc comments are stripped by tsc and cannot produce
+// executable code in the emitted JavaScript.
+
+import { IConjureDefinition, ITypeDefinition } from "conjure-api";
+import { createHashableTypeName } from "./hashingUtils";
+import { validateEnumDefinition } from "./validators/enumValidator";
+import { validateErrorDefinition } from "./validators/errorValidator";
+import { validateFieldName, validateUniqueFieldNames } from "./validators/fieldNameValidator";
+import { validatePackageName } from "./validators/packageValidator";
+import { validateServiceDefinition } from "./validators/serviceValidator";
+import { validateTypeName } from "./validators/typeNameValidator";
+import {
+    getTypeName,
+    validateNoIllegalMapKeys,
+    validateNoNestedOptionals,
+    validateNoRecursiveTypes,
+} from "./validators/typeValidator";
+import { validateUnionDefinition } from "./validators/unionValidator";
+
+// Port of ConjureDefinitionValidator.UniqueServiceNamesValidator
+function validateUniqueServiceNames(definition: IConjureDefinition): void {
+    const seen = new Set<string>();
+    for (const service of definition.services) {
+        const name = service.serviceName.name;
+        if (seen.has(name)) {
+            throw new Error(`Duplicate service name: ${name}`);
+        }
+        seen.add(name);
+    }
+}
+
+// Port of ConjureDefinitionValidator.UniqueNamesValidator
+function validateUniqueNames(definition: IConjureDefinition): void {
+    const seen = new Set<string>();
+
+    for (const typeDef of definition.types) {
+        const key = createHashableTypeName(getTypeName(typeDef));
+        if (seen.has(key)) {
+            throw new Error(`Duplicate type/error/service name: ${key}`);
+        }
+        seen.add(key);
+    }
+
+    for (const errorDef of definition.errors) {
+        const key = createHashableTypeName(errorDef.errorName);
+        if (seen.has(key)) {
+            throw new Error(`Duplicate type/error/service name: ${key}`);
+        }
+        seen.add(key);
+    }
+
+    for (const serviceDef of definition.services) {
+        const key = createHashableTypeName(serviceDef.serviceName);
+        if (seen.has(key)) {
+            throw new Error(`Duplicate type/error/service name: ${key}`);
+        }
+        seen.add(key);
+    }
+}
+
+// Port of ConjureDefinitionValidator.UniqueErrorNameValidator
+function validateUniqueErrorNames(definition: IConjureDefinition): void {
+    const seen = new Set<string>();
+    for (const errorDef of definition.errors) {
+        const key = `${errorDef.namespace}:${errorDef.errorName.name}`;
+        if (seen.has(key)) {
+            throw new Error(`Duplicate error name: ${key}`);
+        }
+        seen.add(key);
+    }
+}
+
+// Compute knownTypes map (same as generator.ts:105-135 but without error types for validation)
+function computeKnownTypes(definition: IConjureDefinition): Map<string, ITypeDefinition> {
+    const knownTypes = new Map<string, ITypeDefinition>();
+
+    for (const typeDef of definition.types) {
+        const typeName = getTypeName(typeDef);
+        knownTypes.set(createHashableTypeName(typeName), typeDef);
+    }
+
+    return knownTypes;
+}
+
+/**
+ * Validates a Conjure IR definition against all conjure-core validation rules.
+ * This is a direct port of ConjureDefinitionValidator.validateAll() from the Java implementation.
+ *
+ * Throws an Error with a descriptive message on the first validation failure.
+ */
+export function validateConjureDefinition(definition: IConjureDefinition): void {
+    // --- Top-level orchestrator validators ---
+
+    // 1. Unique service names
+    validateUniqueServiceNames(definition);
+
+    // 2. (Skipping IllegalVersion — IR version checking is out of scope)
+    // (Skipping LogSafetyConjureDefinitionValidator — requires SafetyDeclarationRequirements
+    //  config which is a compile-time policy flag. We receive pre-compiled IR where the Conjure
+    //  compiler already enforced this.)
+
+    // 3. No recursive types
+    validateNoRecursiveTypes(definition);
+
+    // 4. Unique names across types, errors, services
+    validateUniqueNames(definition);
+
+    // Compute known types for dealiasing-dependent validators
+    const knownTypes = computeKnownTypes(definition);
+
+    // 5. No nested optionals
+    validateNoNestedOptionals(definition, knownTypes);
+
+    // 6. No illegal map keys
+    validateNoIllegalMapKeys(definition, knownTypes);
+
+    // 7. Unique error names
+    validateUniqueErrorNames(definition);
+
+    // --- Per-type validators ---
+
+    for (const typeDef of definition.types) {
+        const typeName = getTypeName(typeDef);
+        const context = `type ${typeName.name}`;
+        validateTypeName(typeName.name, context);
+        validatePackageName(typeName.package, context);
+
+        if (ITypeDefinition.isEnum(typeDef)) {
+            validateEnumDefinition(typeDef.enum);
+        } else if (ITypeDefinition.isObject(typeDef)) {
+            // Validate field names
+            const fieldNames = typeDef.object.fields.map(f => f.fieldName);
+            for (const fieldName of fieldNames) {
+                validateFieldName(fieldName, `object ${typeName.name}`);
+            }
+            validateUniqueFieldNames(fieldNames, `ObjectDefinition ${typeName.name}`);
+        } else if (ITypeDefinition.isUnion(typeDef)) {
+            // Validate union member field names (Java does this in parseField())
+            for (const member of typeDef.union.union) {
+                validateFieldName(member.fieldName, `union ${typeName.name}`);
+            }
+            validateUnionDefinition(typeDef.union);
+        }
+    }
+
+    // --- Per-service validators (includes per-endpoint validation) ---
+
+    for (const serviceDef of definition.services) {
+        validateServiceDefinition(serviceDef, knownTypes);
+    }
+
+    // --- Per-error validators ---
+
+    for (const errorDef of definition.errors) {
+        const context = `error ${errorDef.errorName.name}`;
+        validateTypeName(errorDef.errorName.name, context);
+        validatePackageName(errorDef.errorName.package, context);
+        validateErrorDefinition(errorDef);
+    }
+}

--- a/src/utils/docsUtils.ts
+++ b/src/utils/docsUtils.ts
@@ -17,6 +17,16 @@
 
 import { IEndpointDefinition, IEndpointError, IEnumValueDefinition, IFieldDefinition } from "conjure-api";
 
+/**
+ * Sanitizes a docs string to prevent JSDoc comment breakout.
+ * Replaces `* /` (closing comment sequence) to prevent injecting executable
+ * code via malicious docs fields inside generated TypeScript namespaces.
+ */
+export function sanitizeDocs(docs: string): string {
+    // TODO: implement — currently a passthrough stub for TDD
+    return docs;
+}
+
 type DeprecatableDefinitions = IFieldDefinition | IEnumValueDefinition | IEndpointDefinition;
 
 export const addDeprecatedToDocs = <T extends DeprecatableDefinitions>(typeDefintion: T): string | undefined => {

--- a/src/utils/docsUtils.ts
+++ b/src/utils/docsUtils.ts
@@ -23,24 +23,24 @@ import { IEndpointDefinition, IEndpointError, IEnumValueDefinition, IFieldDefini
  * code via malicious docs fields inside generated TypeScript namespaces.
  */
 export function sanitizeDocs(docs: string): string {
-    // TODO: implement — currently a passthrough stub for TDD
-    return docs;
+    return docs.replace(/\*\//g, "* /");
 }
 
 type DeprecatableDefinitions = IFieldDefinition | IEnumValueDefinition | IEndpointDefinition;
 
 export const addDeprecatedToDocs = <T extends DeprecatableDefinitions>(typeDefintion: T): string | undefined => {
-    if (typeDefintion.deprecated != null && typeDefintion.deprecated != null) {
-        if (typeDefintion.docs != null && typeDefintion.docs != null) {
-            // Do not add deprecated JSDoc if already exists
-            if (typeDefintion.docs.indexOf("@deprecated") === -1) {
-                return `${typeDefintion.docs}\n@deprecated ${typeDefintion.deprecated}`;
+    const docs = typeDefintion.docs != null ? sanitizeDocs(typeDefintion.docs) : undefined;
+    const deprecated = typeDefintion.deprecated != null ? sanitizeDocs(typeDefintion.deprecated) : undefined;
+    if (deprecated != null) {
+        if (docs != null) {
+            if (docs.indexOf("@deprecated") === -1) {
+                return `${docs}\n@deprecated ${deprecated}`;
             }
         } else {
-            return `@deprecated ${typeDefintion.deprecated}`;
+            return `@deprecated ${deprecated}`;
         }
     }
-    return typeDefintion.docs != null ? typeDefintion.docs : undefined;
+    return docs;
 };
 
 export const addIncubatingToDocs = (
@@ -76,8 +76,8 @@ export const addErrorsToDocs = (
 
 const formattedEndpointError = (errorDefinition: IEndpointError): string => {
     let formattedString = `{I${errorDefinition.error.name}}`;
-    if (errorDefinition.docs != null && errorDefinition.docs != null) {
-        formattedString += ` ${errorDefinition.docs}`;
+    if (errorDefinition.docs != null) {
+        formattedString += ` ${sanitizeDocs(errorDefinition.docs)}`;
     }
     return formattedString;
 };

--- a/src/utils/validators/endpointValidator.ts
+++ b/src/utils/validators/endpointValidator.ts
@@ -1,0 +1,369 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core EndpointDefinitionValidator.java (13 sub-validators)
+
+import { IEndpointDefinition, IParameterType, IType, ITypeDefinition } from "conjure-api";
+import { matchesAnyFieldNameCase, matchesCamelCase } from "./fieldNameValidator";
+import { pathArgs } from "./httpPathValidator";
+import { dealias, isAny, isBearerToken, isBinary, isEnum, isPrimitive } from "./typeValidator";
+
+const HEADER_PATTERN = /^[A-Z][a-zA-Z0-9]*(-[A-Z][a-zA-Z0-9]*)*$/;
+const PROTOCOL_HEADERS = new Set(["Host", "Accept", "Content-Type"]);
+
+function describe(endpoint: IEndpointDefinition): string {
+    return `${endpoint.endpointName}{http: ${endpoint.httpMethod} ${endpoint.httpPath}}`;
+}
+
+// Validator 1: NonBodyArgumentTypeValidator
+// Non-body parameters cannot contain 'binary' or 'any' types
+function validateNonBodyArgumentTypes(endpoint: IEndpointDefinition, knownTypes: Map<string, ITypeDefinition>): void {
+    for (const arg of endpoint.args) {
+        if (IParameterType.isBody(arg.paramType)) {
+            continue;
+        }
+        if (!validateTypeNotBinaryOrAny(arg.type, knownTypes)) {
+            throw new Error(
+                `Non body parameters cannot contain the 'binary' or 'any' type. ` +
+                    `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+function validateTypeNotBinaryOrAny(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    const resolved = dealias(type, knownTypes);
+    if (resolved === undefined) {
+        return true; // resolved to a type definition (not a primitive)
+    }
+    if (IType.isOptional(resolved)) {
+        return validateTypeNotBinaryOrAny(resolved.optional.itemType, knownTypes);
+    }
+    if (IType.isList(resolved)) {
+        return validateTypeNotBinaryOrAny(resolved.list.itemType, knownTypes);
+    }
+    if (IType.isSet(resolved)) {
+        return validateTypeNotBinaryOrAny(resolved.set.itemType, knownTypes);
+    }
+    return !isBinary(resolved) && !isAny(resolved);
+}
+
+// Validator 2: SingleBodyParamValidator
+function validateSingleBodyParam(endpoint: IEndpointDefinition): void {
+    const bodyParams = endpoint.args.filter(arg => IParameterType.isBody(arg.paramType));
+    if (bodyParams.length > 1) {
+        throw new Error(
+            `Endpoint '${describe(endpoint)}' cannot have multiple body parameters: ` +
+                `[${bodyParams.map(p => p.argName).join(", ")}]`,
+        );
+    }
+}
+
+// Validator 3: PathParamValidator
+function validatePathParams(endpoint: IEndpointDefinition): void {
+    const pathParamIds = new Set<string>();
+    for (const arg of endpoint.args) {
+        if (IParameterType.isPath(arg.paramType)) {
+            if (pathParamIds.has(arg.argName)) {
+                throw new Error(
+                    `Path parameter with identifier "${arg.argName}" is defined multiple times ` +
+                        `for endpoint '${describe(endpoint)}'`,
+                );
+            }
+            pathParamIds.add(arg.argName);
+        }
+    }
+
+    const templateArgs = pathArgs(endpoint.httpPath);
+
+    // Check for extra params not in path
+    pathParamIds.forEach(paramId => {
+        if (!templateArgs.has(paramId)) {
+            throw new Error(
+                `Path parameter "${paramId}" defined in endpoint but not present in path template ` +
+                    `for endpoint '${describe(endpoint)}'`,
+            );
+        }
+    });
+
+    // Check for path template vars not in params
+    templateArgs.forEach(templateArg => {
+        if (!pathParamIds.has(templateArg)) {
+            throw new Error(
+                `Path parameter "${templateArg}" defined in path template but not present in endpoint ` +
+                    `for endpoint '${describe(endpoint)}'`,
+            );
+        }
+    });
+}
+
+// Validator 4: NoBearerTokenPathOrQueryParams
+function validateNoBearerTokenPathOrQuery(
+    endpoint: IEndpointDefinition,
+    knownTypes: Map<string, ITypeDefinition>,
+): void {
+    for (const arg of endpoint.args) {
+        if (!IParameterType.isPath(arg.paramType) && !IParameterType.isQuery(arg.paramType)) {
+            continue;
+        }
+        if (!validateTypeNotBearerToken(arg.type, knownTypes)) {
+            throw new Error(
+                `Path or query parameters of type 'bearertoken' are not allowed. ` +
+                    `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+function validateTypeNotBearerToken(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    const resolved = dealias(type, knownTypes);
+    if (resolved === undefined) {
+        return true;
+    }
+    if (IType.isOptional(resolved)) {
+        return validateTypeNotBearerToken(resolved.optional.itemType, knownTypes);
+    }
+    if (IType.isList(resolved)) {
+        return validateTypeNotBearerToken(resolved.list.itemType, knownTypes);
+    }
+    if (IType.isSet(resolved)) {
+        return validateTypeNotBearerToken(resolved.set.itemType, knownTypes);
+    }
+    return !isBearerToken(resolved);
+}
+
+// Validator 5: NoComplexPathParamValidator
+function validateNoComplexPathParams(endpoint: IEndpointDefinition, knownTypes: Map<string, ITypeDefinition>): void {
+    for (const arg of endpoint.args) {
+        if (!IParameterType.isPath(arg.paramType)) {
+            continue;
+        }
+        if (!isPrimitive(arg.type, knownTypes) && !isEnum(arg.type, knownTypes)) {
+            throw new Error(
+                `Path parameters must be primitives or aliases to primitives or enums. ` +
+                    `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+// Validator 6: NoComplexHeaderParamValidator
+function validateNoComplexHeaderParams(endpoint: IEndpointDefinition, knownTypes: Map<string, ITypeDefinition>): void {
+    for (const arg of endpoint.args) {
+        if (!IParameterType.isHeader(arg.paramType)) {
+            continue;
+        }
+        if (!validateHeaderType(arg.type, knownTypes)) {
+            throw new Error(
+                `Header parameters must be enums, primitives, aliases or optional primitive. ` +
+                    `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+function validateHeaderType(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    // Dealias first (matching Java's visitor.dealias(type).fold(...))
+    if (isEnum(type, knownTypes)) {
+        return true;
+    }
+    const resolved = dealias(type, knownTypes);
+    if (resolved === undefined) {
+        return false; // resolved to a non-enum type definition
+    }
+    if (IType.isPrimitive(resolved)) {
+        return true;
+    }
+    if (IType.isOptional(resolved)) {
+        return validateHeaderType(resolved.optional.itemType, knownTypes);
+    }
+    return false;
+}
+
+// Validator 7: NoComplexQueryParamValidator
+function validateNoComplexQueryParams(endpoint: IEndpointDefinition, knownTypes: Map<string, ITypeDefinition>): void {
+    for (const arg of endpoint.args) {
+        if (!IParameterType.isQuery(arg.paramType)) {
+            continue;
+        }
+        if (!validateQueryType(arg.type, knownTypes, false)) {
+            throw new Error(
+                `Query parameters must be enums or primitives when de-aliased. ` +
+                    `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+function validateQueryType(type: IType, knownTypes: Map<string, ITypeDefinition>, isNested: boolean): boolean {
+    // Dealias first (matching Java's visitor.dealias(type).fold(...))
+    if (isEnum(type, knownTypes)) {
+        return true;
+    }
+    const resolved = dealias(type, knownTypes);
+    if (resolved === undefined) {
+        return false; // resolved to a non-enum type definition
+    }
+    if (IType.isPrimitive(resolved)) {
+        return !isAny(resolved);
+    }
+    if (IType.isOptional(resolved) && !isNested) {
+        return validateQueryType(resolved.optional.itemType, knownTypes, true);
+    }
+    if (IType.isList(resolved) && !isNested) {
+        return validateQueryType(resolved.list.itemType, knownTypes, true);
+    }
+    if (IType.isSet(resolved) && !isNested) {
+        return validateQueryType(resolved.set.itemType, knownTypes, true);
+    }
+    return false;
+}
+
+// Validator 8: NoGetBodyParamValidator
+function validateNoGetBody(endpoint: IEndpointDefinition): void {
+    if (endpoint.httpMethod.toString() === "GET") {
+        const hasBody = endpoint.args.some(arg => IParameterType.isBody(arg.paramType));
+        if (hasBody) {
+            throw new Error(`Endpoint '${describe(endpoint)}' cannot be a GET and contain a body`);
+        }
+    }
+}
+
+// Validator 9: NoOptionalBinaryBodyParamValidator
+function validateNoOptionalBinaryBody(endpoint: IEndpointDefinition, knownTypes: Map<string, ITypeDefinition>): void {
+    for (const arg of endpoint.args) {
+        if (!IParameterType.isBody(arg.paramType)) {
+            continue;
+        }
+        const resolved = dealias(arg.type, knownTypes);
+        if (resolved !== undefined && IType.isOptional(resolved)) {
+            const inner = dealias(resolved.optional.itemType, knownTypes);
+            if (inner !== undefined && isBinary(inner)) {
+                throw new Error(
+                    `Endpoint BODY argument must not be optional<binary> or alias thereof. ` +
+                        `Parameter '${arg.argName}' in endpoint '${describe(endpoint)}'`,
+                );
+            }
+        }
+    }
+}
+
+// Validator 10: ParameterNameValidator
+function validateParameterNames(endpoint: IEndpointDefinition): void {
+    for (const arg of endpoint.args) {
+        if (!matchesCamelCase(arg.argName)) {
+            throw new Error(
+                `Parameter names in endpoint paths and service definitions must be camelCase: ` +
+                    `"${arg.argName}" on endpoint '${describe(endpoint)}'`,
+            );
+        }
+    }
+}
+
+// Validator 11: ParamIdValidator
+function validateParamIds(endpoint: IEndpointDefinition): void {
+    for (const arg of endpoint.args) {
+        if (IParameterType.isBody(arg.paramType) || IParameterType.isPath(arg.paramType)) {
+            continue;
+        }
+
+        if (IParameterType.isHeader(arg.paramType)) {
+            const paramId = arg.paramType.header.paramId;
+            if (paramId != null) {
+                if (!HEADER_PATTERN.test(paramId)) {
+                    throw new Error(
+                        `Header parameter id "${paramId}" on endpoint '${describe(endpoint)}' ` +
+                            `must match pattern ${HEADER_PATTERN}`,
+                    );
+                }
+                if (PROTOCOL_HEADERS.has(paramId)) {
+                    throw new Error(
+                        `Header parameter id "${paramId}" on endpoint '${describe(endpoint)}' ` +
+                            `should not be one of the protocol headers: ${Array.from(PROTOCOL_HEADERS).join(", ")}`,
+                    );
+                }
+            }
+        } else if (IParameterType.isQuery(arg.paramType)) {
+            const paramId = arg.paramType.query.paramId;
+            if (paramId != null && !matchesAnyFieldNameCase(paramId)) {
+                throw new Error(
+                    `Query param id "${paramId}" on endpoint '${describe(endpoint)}' ` +
+                        `must match one of: camelCase, kebab-case, or snake_case`,
+                );
+            }
+        }
+    }
+}
+
+// Validator 12: NoUnsupportedHttpMethodValidator
+function validateHttpMethod(endpoint: IEndpointDefinition): void {
+    const method = endpoint.httpMethod.toString();
+    if (method === "UNKNOWN") {
+        throw new Error(`HTTP method must not be UNKNOWN in endpoint '${describe(endpoint)}'`);
+    }
+}
+
+// Validator 13: NoDuplicateEndpointErrorsValidator
+function validateNoDuplicateEndpointErrors(endpoint: IEndpointDefinition): void {
+    if (endpoint.errors == null) {
+        return;
+    }
+    const seen = new Set<string>();
+    for (const endpointError of endpoint.errors) {
+        const errorTypeName = endpointError.error;
+        const uniqueId = `${errorTypeName.name}:${errorTypeName.namespace}`;
+        if (seen.has(uniqueId)) {
+            throw new Error(
+                `Error '${errorTypeName.name}' with namespace '${errorTypeName.namespace}' ` +
+                    `is declared multiple times in endpoint '${describe(endpoint)}'`,
+            );
+        }
+        seen.add(uniqueId);
+    }
+}
+
+// Defense-in-depth: validate endpointName is a safe identifier.
+// Java validates this at the parser level (EndpointName.of()), not in EndpointDefinitionValidator.
+// Since we receive pre-compiled IR, we validate here to prevent code injection via method names.
+function validateEndpointName(endpoint: IEndpointDefinition): void {
+    if (!matchesCamelCase(endpoint.endpointName)) {
+        throw new Error(
+            `Endpoint names must be camelCase: "${endpoint.endpointName}" in endpoint '${describe(endpoint)}'`,
+        );
+    }
+}
+
+// Port of EndpointDefinitionValidator.validateAll()
+export function validateEndpointDefinition(
+    endpoint: IEndpointDefinition,
+    knownTypes: Map<string, ITypeDefinition>,
+): void {
+    validateEndpointName(endpoint);
+    validateNonBodyArgumentTypes(endpoint, knownTypes);
+    validateSingleBodyParam(endpoint);
+    validatePathParams(endpoint);
+    validateNoBearerTokenPathOrQuery(endpoint, knownTypes);
+    validateNoComplexPathParams(endpoint, knownTypes);
+    validateNoComplexHeaderParams(endpoint, knownTypes);
+    validateNoComplexQueryParams(endpoint, knownTypes);
+    validateNoGetBody(endpoint);
+    validateNoOptionalBinaryBody(endpoint, knownTypes);
+    validateParameterNames(endpoint);
+    validateParamIds(endpoint);
+    validateHttpMethod(endpoint);
+    validateNoDuplicateEndpointErrors(endpoint);
+}

--- a/src/utils/validators/enumValidator.ts
+++ b/src/utils/validators/enumValidator.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core EnumDefinitionValidator.java + EnumValueDefinitionValidator.java + EnumPattern.java
+// Enum value pattern: [A-Z][A-Z0-9]*(_[A-Z0-9]+)*
+
+import { IEnumDefinition } from "conjure-api";
+
+const ENUM_VALUE_PATTERN = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
+
+// Port of EnumValueDefinitionValidator.FormatValidator
+export function validateEnumValue(value: string, context: string): void {
+    if (!ENUM_VALUE_PATTERN.test(value)) {
+        throw new Error(`Enumeration values must match format ${ENUM_VALUE_PATTERN}: "${value}" in ${context}`);
+    }
+}
+
+// Port of EnumValueDefinitionValidator.UnknownValueNotUsedValidator
+export function validateEnumValueNotUnknown(value: string, context: string): void {
+    if (value.toUpperCase() === "UNKNOWN") {
+        throw new Error(`UNKNOWN is a reserved enumeration value and cannot be used in ${context}`);
+    }
+}
+
+// Port of EnumDefinitionValidator.UniqueEnumValuesValidator
+function validateUniqueEnumValues(definition: IEnumDefinition, context: string): void {
+    const seen = new Set<string>();
+    for (const valueDef of definition.values) {
+        if (seen.has(valueDef.value)) {
+            throw new Error(`Cannot declare an enum with duplicate enum values: "${valueDef.value}" in ${context}`);
+        }
+        seen.add(valueDef.value);
+    }
+}
+
+// Port of EnumDefinitionValidator.validateAll()
+export function validateEnumDefinition(definition: IEnumDefinition): void {
+    const context = `enum ${definition.typeName.name}`;
+    validateUniqueEnumValues(definition, context);
+    for (const valueDef of definition.values) {
+        validateEnumValue(valueDef.value, context);
+        validateEnumValueNotUnknown(valueDef.value, context);
+    }
+}

--- a/src/utils/validators/errorValidator.ts
+++ b/src/utils/validators/errorValidator.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core ErrorDefinitionValidator.java + ErrorNamespaceValidator.java
+// Note: Error namespace and error code validation are handled at the parser/compiler level in Java,
+// not in ConjureDefinitionValidator.validateAll(). We include them here as defense-in-depth since
+// we receive pre-compiled IR and cannot assume upstream validation has run.
+
+import { IErrorDefinition } from "conjure-api";
+import { convertToCamelCase, validateFieldName } from "./fieldNameValidator";
+
+// Port of ErrorNamespaceValidator
+// Pattern: (([A-Z][a-z0-9]+)+) — same structure as TypeName (PascalCase)
+const ERROR_NAMESPACE_PATTERN = /^([A-Z][a-z0-9]+)+$/;
+
+export function validateErrorNamespace(namespace: string, context: string): void {
+    if (!ERROR_NAMESPACE_PATTERN.test(namespace)) {
+        throw new Error(
+            `Namespace for errors must match pattern ${ERROR_NAMESPACE_PATTERN}: "${namespace}" in ${context}`,
+        );
+    }
+}
+
+// Valid error codes (fixed enum from conjure spec)
+const VALID_ERROR_CODES = new Set([
+    "PERMISSION_DENIED",
+    "INVALID_ARGUMENT",
+    "NOT_FOUND",
+    "CONFLICT",
+    "REQUEST_ENTITY_TOO_LARGE",
+    "FAILED_PRECONDITION",
+    "INTERNAL",
+    "TIMEOUT",
+    "CUSTOM_CLIENT",
+    "CUSTOM_SERVER",
+]);
+
+export function validateErrorCode(code: string, context: string): void {
+    if (!VALID_ERROR_CODES.has(code)) {
+        throw new Error(
+            `Invalid error code "${code}" in ${context}. ` +
+                `Must be one of: ${Array.from(VALID_ERROR_CODES).join(", ")}`,
+        );
+    }
+}
+
+// Port of ErrorDefinitionValidator — unique field names across safe+unsafe args
+export function validateErrorDefinition(definition: IErrorDefinition): void {
+    const context = `error ${definition.errorName.name}`;
+
+    // Validate namespace
+    if (definition.namespace != null) {
+        validateErrorNamespace(definition.namespace, context);
+    }
+
+    // Validate error code
+    validateErrorCode(definition.code, context);
+
+    // Validate and collect field names for uniqueness check
+    const allArgs = (definition.safeArgs || []).concat(definition.unsafeArgs || []);
+    const seenNormalized = new Map<string, string>();
+
+    for (const arg of allArgs) {
+        validateFieldName(arg.fieldName, context);
+
+        const normalized = convertToCamelCase(arg.fieldName);
+        const existing = seenNormalized.get(normalized);
+        if (existing !== undefined) {
+            throw new Error(
+                `${context} must not contain duplicate field names (modulo case normalization): ` +
+                    `${arg.fieldName} vs ${existing}`,
+            );
+        }
+        seenNormalized.set(normalized, arg.fieldName);
+    }
+
+    // Safety is implicit from safeArgs/unsafeArgs placement — explicit declarations are not allowed
+    const fieldsDeclaringSafety = allArgs.filter(arg => arg.safety != null).map(arg => arg.fieldName);
+    if (fieldsDeclaringSafety.length > 0) {
+        throw new Error(
+            `ErrorDefinition field safety is defined by the key 'safeArgs' or 'unsafeArgs', ` +
+                `safety cannot be declared: ${fieldsDeclaringSafety.join(", ")} in ${context}`,
+        );
+    }
+}

--- a/src/utils/validators/fieldNameValidator.ts
+++ b/src/utils/validators/fieldNameValidator.ts
@@ -110,9 +110,9 @@ export function matchesAnyFieldNameCase(value: string): boolean {
     return matchesCamelCase(value) || matchesKebabCase(value) || matchesSnakeCase(value);
 }
 
-export type FieldNameCase = "camelCase" | "kebabCase" | "snakeCase";
+type FieldNameCase = "camelCase" | "kebabCase" | "snakeCase";
 
-export function detectCase(value: string): FieldNameCase | undefined {
+function detectCase(value: string): FieldNameCase | undefined {
     if (matchesCamelCase(value)) {
         return "camelCase";
     }

--- a/src/utils/validators/fieldNameValidator.ts
+++ b/src/utils/validators/fieldNameValidator.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core Java validators:
+// - CamelCasePattern, KebabCasePattern, SnakeCasePattern (conjure-generator-common)
+// - CaseConverter (conjure-generator-common)
+// - FieldNameValidator (conjure-core)
+// - UniqueFieldNamesValidator (conjure-core)
+
+function isLower(ch: string): boolean {
+    return ch >= "a" && ch <= "z";
+}
+
+function isUpper(ch: string): boolean {
+    return ch >= "A" && ch <= "Z";
+}
+
+function isNumeric(ch: string): boolean {
+    return ch >= "0" && ch <= "9";
+}
+
+// Port of CamelCasePattern.matches()
+// Regex equivalent: ^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$
+export function matchesCamelCase(value: string): boolean {
+    if (value.length === 0 || !isLower(value[0])) {
+        return false;
+    }
+    let uppercaseChars = 0;
+    for (let i = 1; i < value.length; i++) {
+        const ch = value[i];
+        if (isLower(ch) || isNumeric(ch)) {
+            uppercaseChars = 0;
+        } else if (isUpper(ch)) {
+            if (uppercaseChars >= 2) {
+                return false;
+            }
+            uppercaseChars++;
+        } else {
+            return false;
+        }
+    }
+    return uppercaseChars <= 1;
+}
+
+// Port of KebabCasePattern.matches()
+// Regex equivalent: ^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$
+export function matchesKebabCase(value: string): boolean {
+    if (value.length === 0 || !isLower(value[0])) {
+        return false;
+    }
+    let dashChars = 0;
+    for (let i = 1; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === "-") {
+            i++;
+            if (i >= value.length || dashChars >= 2 || !isLower(value[i])) {
+                return false;
+            }
+            dashChars++;
+        } else {
+            dashChars = 0;
+            if (!isLower(ch) && !isNumeric(ch)) {
+                return false;
+            }
+        }
+    }
+    return dashChars <= 1;
+}
+
+// Port of SnakeCasePattern.matches()
+// Regex equivalent: ^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$
+export function matchesSnakeCase(value: string): boolean {
+    if (value.length === 0 || !isLower(value[0])) {
+        return false;
+    }
+    let underscoreChars = 0;
+    for (let i = 1; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === "_") {
+            i++;
+            if (i >= value.length || underscoreChars >= 2 || !isLower(value[i])) {
+                return false;
+            }
+            underscoreChars++;
+        } else {
+            underscoreChars = 0;
+            if (!isLower(ch) && !isNumeric(ch)) {
+                return false;
+            }
+        }
+    }
+    return underscoreChars <= 1;
+}
+
+export function matchesAnyFieldNameCase(value: string): boolean {
+    return matchesCamelCase(value) || matchesKebabCase(value) || matchesSnakeCase(value);
+}
+
+export type FieldNameCase = "camelCase" | "kebabCase" | "snakeCase";
+
+export function detectCase(value: string): FieldNameCase | undefined {
+    if (matchesCamelCase(value)) {
+        return "camelCase";
+    }
+    if (matchesKebabCase(value)) {
+        return "kebabCase";
+    }
+    if (matchesSnakeCase(value)) {
+        return "snakeCase";
+    }
+    return undefined;
+}
+
+// Port of CaseConverter: convert between camelCase, kebab-case, and snake_case
+
+function splitKebabCase(value: string): string[] {
+    return value.split("-");
+}
+
+function splitSnakeCase(value: string): string[] {
+    return value.split("_");
+}
+
+function toCamelCase(parts: string[]): string {
+    return (
+        parts[0] +
+        parts
+            .slice(1)
+            .map(p => p.charAt(0).toUpperCase() + p.slice(1))
+            .join("")
+    );
+}
+
+export function convertToCamelCase(value: string): string {
+    const nameCase = detectCase(value);
+    if (nameCase === undefined) {
+        throw new Error(`Cannot convert field name to camelCase, unrecognized case: ${value}`);
+    }
+    switch (nameCase) {
+        case "camelCase":
+            return value;
+        case "kebabCase":
+            return toCamelCase(splitKebabCase(value));
+        case "snakeCase":
+            return toCamelCase(splitSnakeCase(value));
+    }
+}
+
+// Port of FieldNameValidator.validate()
+export function validateFieldName(fieldName: string, context: string): void {
+    if (!matchesAnyFieldNameCase(fieldName)) {
+        throw new Error(
+            `FieldName "${fieldName}" in ${context} must follow one of the following patterns: ` +
+                `camelCase, kebab-case, or snake_case.`,
+        );
+    }
+}
+
+// Port of UniqueFieldNamesValidator
+export function validateUniqueFieldNames(fieldNames: string[], context: string): void {
+    const seenNormalized = new Map<string, string>();
+    for (const fieldName of fieldNames) {
+        const normalized = convertToCamelCase(fieldName);
+        const existing = seenNormalized.get(normalized);
+        if (existing !== undefined) {
+            throw new Error(
+                `${context} must not contain duplicate field names (modulo case normalization): ` +
+                    `${fieldName} vs ${existing}`,
+            );
+        }
+        seenNormalized.set(normalized, fieldName);
+    }
+}

--- a/src/utils/validators/httpPathValidator.ts
+++ b/src/utils/validators/httpPathValidator.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core HttpPathValidator.java
+
+const SEGMENT_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
+const PARAM_PATTERN = /^[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*$/;
+
+// Extract path parameter names from a path template
+export function pathArgs(httpPath: string): Set<string> {
+    const args = new Set<string>();
+    const segments = httpPath.split("/");
+    for (const segment of segments) {
+        if (segment.startsWith("{") && segment.endsWith("}")) {
+            const inner = segment.slice(1, -1);
+            // Strip optional regex suffix (e.g., {param:.+})
+            const paramName = inner.split(":")[0];
+            args.add(paramName);
+        }
+    }
+    return args;
+}
+
+export function validateHttpPath(httpPath: string, context: string): void {
+    // Must be absolute
+    if (!httpPath.startsWith("/")) {
+        throw new Error(`Conjure paths must be absolute, i.e., start with '/': "${httpPath}" in ${context}`);
+    }
+
+    // Must not end with / (unless it's just "/")
+    if (httpPath.length > 1 && httpPath.endsWith("/")) {
+        throw new Error(`Conjure paths must not end with a '/': "${httpPath}" in ${context}`);
+    }
+
+    const segments = httpPath.split("/").slice(1); // skip empty string before leading /
+
+    for (const segment of segments) {
+        if (segment.length === 0) {
+            throw new Error(
+                `Conjure paths must not contain empty segments (consecutive '/'): "${httpPath}" in ${context}`,
+            );
+        }
+
+        if (segment.startsWith("{") && segment.endsWith("}")) {
+            // Parameter segment — validate the parameter name
+            const inner = segment.slice(1, -1);
+            const colonIdx = inner.indexOf(":");
+            const paramName = colonIdx >= 0 ? inner.substring(0, colonIdx) : inner;
+            const regexPart = colonIdx >= 0 ? inner.substring(colonIdx + 1) : null;
+
+            if (!PARAM_PATTERN.test(paramName)) {
+                throw new Error(
+                    `Segment ${segment} of path ${httpPath} has invalid parameter name "${paramName}". ` +
+                        `Parameter names must match ${PARAM_PATTERN} in ${context}`,
+                );
+            }
+
+            // Validate regex if present: only .+ or .* allowed
+            if (regexPart !== null && regexPart !== ".+" && regexPart !== ".*") {
+                throw new Error(
+                    `Path parameter ${paramName} in path ${httpPath} specifies unsupported ` +
+                        `regular expression "${regexPart}". Only ".+" and ".*" are supported in ${context}`,
+                );
+            }
+        } else if (!SEGMENT_PATTERN.test(segment)) {
+            throw new Error(
+                `Segment "${segment}" of path ${httpPath} did not match required segment pattern ` +
+                    `${SEGMENT_PATTERN} in ${context}`,
+            );
+        }
+    }
+
+    // Validate template variables are unique
+    const templateVars = new Set<string>();
+    for (const segment of segments) {
+        if (segment.startsWith("{") && segment.endsWith("}")) {
+            const inner = segment.slice(1, -1);
+            const paramName = inner.split(":")[0];
+            if (templateVars.has(paramName)) {
+                throw new Error(
+                    `Path parameter "${paramName}" appears more than once in path ${httpPath} in ${context}`,
+                );
+            }
+            templateVars.add(paramName);
+        }
+    }
+
+    // Validate .* regex only in last segment
+    for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i];
+        if (segment.startsWith("{") && segment.endsWith("}")) {
+            const inner = segment.slice(1, -1);
+            const colonIdx = inner.indexOf(":");
+            if (colonIdx >= 0) {
+                const regexPart = inner.substring(colonIdx + 1);
+                if (regexPart === ".*" && i !== segments.length - 1) {
+                    const paramName = inner.substring(0, colonIdx);
+                    throw new Error(
+                        `Path parameter "${paramName}" in path ${httpPath} specifies regular expression ".*", ` +
+                            `but this is only permitted in the last segment in ${context}`,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/utils/validators/packageValidator.ts
+++ b/src/utils/validators/packageValidator.ts
@@ -15,10 +15,13 @@
  * limitations under the License.
  */
 
-export function doubleQuote(value: string): string {
-    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
+// Direct port of conjure-core PackageValidator.java + PackagePattern.java
+// Pattern: ^([a-z][a-z0-9]+(\.[a-z][a-z0-9]*)*)?$
 
-export function singleQuote(value: string): string {
-    return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+const PACKAGE_PATTERN = /^([a-z][a-z0-9]+(\.[a-z][a-z0-9]*)*)?$/;
+
+export function validatePackageName(name: string, context: string): void {
+    if (!PACKAGE_PATTERN.test(name)) {
+        throw new Error(`Conjure package names must match pattern ${PACKAGE_PATTERN}: "${name}" in ${context}`);
+    }
 }

--- a/src/utils/validators/serviceValidator.ts
+++ b/src/utils/validators/serviceValidator.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core ServiceDefinitionValidator.java
+// Two sub-validators: UniquePathMethods, IllegalSuffixes
+
+import { IServiceDefinition, ITypeDefinition } from "conjure-api";
+import { validateEndpointDefinition } from "./endpointValidator";
+import { validateHttpPath } from "./httpPathValidator";
+import { validatePackageName } from "./packageValidator";
+import { validateTypeName } from "./typeNameValidator";
+
+const PATHVAR_PATTERN = /\{.+?\}/g;
+const RETROFIT_SUFFIX = "Retrofit";
+
+// Port of ServiceDefinitionValidator.UniquePathMethodsValidator
+function validateUniquePathMethods(definition: IServiceDefinition): void {
+    const pathToEndpoints = new Map<string, string[]>();
+
+    for (const endpoint of definition.endpoints) {
+        let methodPath = `${endpoint.httpMethod} ${endpoint.httpPath}`;
+        // Normalize all path parameter variables to {arg}
+        methodPath = methodPath.replace(PATHVAR_PATTERN, "{arg}");
+
+        const existing = pathToEndpoints.get(methodPath);
+        if (existing !== undefined) {
+            existing.push(endpoint.endpointName);
+        } else {
+            pathToEndpoints.set(methodPath, [endpoint.endpointName]);
+        }
+    }
+
+    pathToEndpoints.forEach((endpoints, key) => {
+        if (endpoints.length > 1) {
+            throw new Error(`Endpoint "${key}" is defined by multiple endpoints: [${endpoints.join(", ")}]`);
+        }
+    });
+}
+
+// Port of ServiceDefinitionValidator.IllegalSuffixesValidator
+function validateIllegalSuffixes(definition: IServiceDefinition): void {
+    if (definition.serviceName.name.endsWith(RETROFIT_SUFFIX)) {
+        throw new Error(`Service name must not end in ${RETROFIT_SUFFIX}: ${definition.serviceName.name}`);
+    }
+}
+
+// Port of ServiceDefinitionValidator.validateAll() + per-endpoint validation
+export function validateServiceDefinition(
+    definition: IServiceDefinition,
+    knownTypes: Map<string, ITypeDefinition>,
+): void {
+    const context = `service ${definition.serviceName.name}`;
+
+    validateTypeName(definition.serviceName.name, context);
+    validatePackageName(definition.serviceName.package, context);
+    validateUniquePathMethods(definition);
+    validateIllegalSuffixes(definition);
+
+    for (const endpoint of definition.endpoints) {
+        validateHttpPath(endpoint.httpPath, `${context} endpoint ${endpoint.endpointName}`);
+        validateEndpointDefinition(endpoint, knownTypes);
+    }
+}

--- a/src/utils/validators/typeNameValidator.ts
+++ b/src/utils/validators/typeNameValidator.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core TypeNameValidator.java
+// Pattern: ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$
+
+const TYPE_NAME_PATTERN = /^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$/;
+
+const PRIMITIVE_TYPES = new Set([
+    "STRING",
+    "DATETIME",
+    "INTEGER",
+    "DOUBLE",
+    "SAFELONG",
+    "BINARY",
+    "ANY",
+    "BOOLEAN",
+    "UUID",
+    "RID",
+    "BEARERTOKEN",
+]);
+
+export function validateTypeName(name: string, context: string): void {
+    if (!TYPE_NAME_PATTERN.test(name) && !PRIMITIVE_TYPES.has(name)) {
+        throw new Error(
+            `TypeNames must be a primitive type or match pattern ${TYPE_NAME_PATTERN}: ` + `"${name}" in ${context}`,
+        );
+    }
+}

--- a/src/utils/validators/typeValidator.ts
+++ b/src/utils/validators/typeValidator.ts
@@ -110,18 +110,9 @@ function collectTypeReferences(type: IType): ITypeName[] {
     if (IType.isReference(type)) {
         return [type.reference];
     }
-    if (IType.isOptional(type)) {
-        return collectTypeReferences(type.optional.itemType);
-    }
-    if (IType.isList(type)) {
-        return collectTypeReferences(type.list.itemType);
-    }
-    if (IType.isSet(type)) {
-        return collectTypeReferences(type.set.itemType);
-    }
-    if (IType.isMap(type)) {
-        return [...collectTypeReferences(type.map.keyType), ...collectTypeReferences(type.map.valueType)];
-    }
+    // Container types (list, set, map, optional) are not traversed — they generate
+    // reference types in TypeScript (Array<T>, T | undefined, etc.) that break
+    // the inline expansion that makes direct recursion invalid.
     return [];
 }
 
@@ -144,13 +135,9 @@ export function validateNoRecursiveTypes(definition: IConjureDefinition): void {
                     refs.add(createHashableTypeName(ref));
                 }
             }
-        } else if (ITypeDefinition.isUnion(typeDef)) {
-            for (const member of typeDef.union.union) {
-                for (const ref of collectTypeReferences(member.type)) {
-                    refs.add(createHashableTypeName(ref));
-                }
-            }
         }
+        // Unions are excluded from recursion detection, matching Java's NoRecursiveTypesValidator.
+        // Union self-references generate valid TypeScript (tagged unions use interfaces).
 
         edges.set(key, refs);
     }
@@ -283,11 +270,18 @@ export function validateNoNestedOptionals(
 function hasIllegalMapKey(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
     if (IType.isMap(type)) {
         const keyType = type.map.keyType;
-        // Map keys must be primitives or references (enums/objects after dealiasing)
-        if (!IType.isPrimitive(keyType) && !IType.isReference(keyType)) {
-            return true;
+        // Map keys must be primitives, enums, or objects — not containers.
+        // References are followed through alias chains to check the resolved type.
+        if (!IType.isPrimitive(keyType)) {
+            if (IType.isReference(keyType)) {
+                const resolved = dealias(keyType, knownTypes);
+                if (resolved !== undefined && !IType.isPrimitive(resolved)) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
         }
-        // Also check value recursively
         return hasIllegalMapKey(type.map.valueType, knownTypes);
     }
     if (IType.isOptional(type)) {

--- a/src/utils/validators/typeValidator.ts
+++ b/src/utils/validators/typeValidator.ts
@@ -1,0 +1,337 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core type graph validators:
+// - NoRecursiveTypesValidator
+// - NoNestedOptionalValidator
+// - IllegalMapKeyValidator
+// - FieldDefinitionValidator
+// Also provides dealiasing utilities used by EndpointDefinitionValidator
+
+import { IConjureDefinition, IType, ITypeDefinition, ITypeName, PrimitiveType } from "conjure-api";
+import { createHashableTypeName } from "../hashingUtils";
+
+// --- Dealiasing utilities ---
+
+/**
+ * Follow alias chains to resolve to the underlying type.
+ * Returns undefined if the type resolves to a TypeDefinition (object, enum, union) rather than a primitive/container.
+ * Returns the resolved IType if it resolves to a primitive or container type.
+ */
+export function dealias(type: IType, knownTypes: Map<string, ITypeDefinition>): IType | undefined {
+    if (IType.isReference(type)) {
+        const refName = createHashableTypeName(type.reference);
+        const typeDef = knownTypes.get(refName);
+        if (typeDef === undefined) {
+            return undefined;
+        }
+        if (ITypeDefinition.isAlias(typeDef)) {
+            return dealias(typeDef.alias.alias, knownTypes);
+        }
+        // Object, enum, union — return undefined to indicate it resolved to a type definition
+        return undefined;
+    }
+    return type;
+}
+
+/**
+ * Check if a type resolves to a TypeDefinition (returns the definition), or to a primitive/container (returns undefined).
+ */
+export function dealiasToDefinition(
+    type: IType,
+    knownTypes: Map<string, ITypeDefinition>,
+): ITypeDefinition | undefined {
+    if (IType.isReference(type)) {
+        const refName = createHashableTypeName(type.reference);
+        const typeDef = knownTypes.get(refName);
+        if (typeDef === undefined) {
+            return undefined;
+        }
+        if (ITypeDefinition.isAlias(typeDef)) {
+            return dealiasToDefinition(typeDef.alias.alias, knownTypes);
+        }
+        return typeDef;
+    }
+    return undefined;
+}
+
+export function isPrimitive(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    const resolved = dealias(type, knownTypes);
+    return resolved !== undefined && IType.isPrimitive(resolved);
+}
+
+export function isEnum(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    const def = dealiasToDefinition(type, knownTypes);
+    return def !== undefined && ITypeDefinition.isEnum(def);
+}
+
+export function isBinary(type: IType): boolean {
+    return IType.isPrimitive(type) && type.primitive === PrimitiveType.BINARY;
+}
+
+export function isAny(type: IType): boolean {
+    return IType.isPrimitive(type) && type.primitive === PrimitiveType.ANY;
+}
+
+export function isBearerToken(type: IType): boolean {
+    return IType.isPrimitive(type) && type.primitive === PrimitiveType.BEARERTOKEN;
+}
+
+// --- NoRecursiveTypesValidator ---
+
+export function getTypeName(typeDef: ITypeDefinition): ITypeName {
+    if (ITypeDefinition.isAlias(typeDef)) {
+        return typeDef.alias.typeName;
+    }
+    if (ITypeDefinition.isEnum(typeDef)) {
+        return typeDef.enum.typeName;
+    }
+    if (ITypeDefinition.isObject(typeDef)) {
+        return typeDef.object.typeName;
+    }
+    if (ITypeDefinition.isUnion(typeDef)) {
+        return typeDef.union.typeName;
+    }
+    throw new Error("Unknown type definition type");
+}
+
+function collectTypeReferences(type: IType): ITypeName[] {
+    if (IType.isReference(type)) {
+        return [type.reference];
+    }
+    if (IType.isOptional(type)) {
+        return collectTypeReferences(type.optional.itemType);
+    }
+    if (IType.isList(type)) {
+        return collectTypeReferences(type.list.itemType);
+    }
+    if (IType.isSet(type)) {
+        return collectTypeReferences(type.set.itemType);
+    }
+    if (IType.isMap(type)) {
+        return [...collectTypeReferences(type.map.keyType), ...collectTypeReferences(type.map.valueType)];
+    }
+    return [];
+}
+
+export function validateNoRecursiveTypes(definition: IConjureDefinition): void {
+    // Build adjacency list: type -> types it references
+    const edges = new Map<string, Set<string>>();
+
+    for (const typeDef of definition.types) {
+        const typeName = getTypeName(typeDef);
+        const key = createHashableTypeName(typeName);
+        const refs = new Set<string>();
+
+        if (ITypeDefinition.isAlias(typeDef)) {
+            for (const ref of collectTypeReferences(typeDef.alias.alias)) {
+                refs.add(createHashableTypeName(ref));
+            }
+        } else if (ITypeDefinition.isObject(typeDef)) {
+            for (const field of typeDef.object.fields) {
+                for (const ref of collectTypeReferences(field.type)) {
+                    refs.add(createHashableTypeName(ref));
+                }
+            }
+        } else if (ITypeDefinition.isUnion(typeDef)) {
+            for (const member of typeDef.union.union) {
+                for (const ref of collectTypeReferences(member.type)) {
+                    refs.add(createHashableTypeName(ref));
+                }
+            }
+        }
+
+        edges.set(key, refs);
+    }
+
+    // DFS cycle detection
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+
+    function dfs(node: string, path: string[]): void {
+        if (inStack.has(node)) {
+            const cycleStart = path.indexOf(node);
+            const cycle = path.slice(cycleStart).concat(node);
+            throw new Error(`Recursive types detected: ${cycle.join(" -> ")}`);
+        }
+        if (visited.has(node)) {
+            return;
+        }
+        visited.add(node);
+        inStack.add(node);
+        path.push(node);
+
+        const neighbors = edges.get(node);
+        if (neighbors !== undefined) {
+            neighbors.forEach(neighbor => {
+                if (edges.has(neighbor)) {
+                    dfs(neighbor, path);
+                }
+            });
+        }
+
+        path.pop();
+        inStack.delete(node);
+    }
+
+    edges.forEach((_refs, node) => {
+        dfs(node, []);
+    });
+}
+
+// --- NoNestedOptionalValidator ---
+
+function hasNestedOptional(type: IType, knownTypes: Map<string, ITypeDefinition>, insideOptional: boolean): boolean {
+    if (IType.isOptional(type)) {
+        if (insideOptional) {
+            return true;
+        }
+        return hasNestedOptional(type.optional.itemType, knownTypes, true);
+    }
+    if (IType.isReference(type)) {
+        const resolved = dealias(type, knownTypes);
+        if (resolved !== undefined) {
+            return hasNestedOptional(resolved, knownTypes, insideOptional);
+        }
+        return false;
+    }
+    if (IType.isList(type)) {
+        return hasNestedOptional(type.list.itemType, knownTypes, false);
+    }
+    if (IType.isSet(type)) {
+        return hasNestedOptional(type.set.itemType, knownTypes, false);
+    }
+    if (IType.isMap(type)) {
+        return (
+            hasNestedOptional(type.map.keyType, knownTypes, false) ||
+            hasNestedOptional(type.map.valueType, knownTypes, false)
+        );
+    }
+    return false;
+}
+
+export function validateNoNestedOptionals(
+    definition: IConjureDefinition,
+    knownTypes: Map<string, ITypeDefinition>,
+): void {
+    for (const typeDef of definition.types) {
+        if (ITypeDefinition.isObject(typeDef)) {
+            for (const field of typeDef.object.fields) {
+                if (hasNestedOptional(field.type, knownTypes, false)) {
+                    throw new Error(
+                        `Nested optionals not allowed: field '${field.fieldName}' ` +
+                            `in type '${typeDef.object.typeName.name}'`,
+                    );
+                }
+            }
+        } else if (ITypeDefinition.isUnion(typeDef)) {
+            for (const member of typeDef.union.union) {
+                if (hasNestedOptional(member.type, knownTypes, false)) {
+                    throw new Error(
+                        `Nested optionals not allowed: member '${member.fieldName}' ` +
+                            `in union '${typeDef.union.typeName.name}'`,
+                    );
+                }
+            }
+        }
+    }
+
+    for (const errorDef of definition.errors) {
+        const allArgs = (errorDef.safeArgs || []).concat(errorDef.unsafeArgs || []);
+        for (const arg of allArgs) {
+            if (hasNestedOptional(arg.type, knownTypes, false)) {
+                throw new Error(
+                    `Nested optionals not allowed: arg '${arg.fieldName}' ` + `in error '${errorDef.errorName.name}'`,
+                );
+            }
+        }
+    }
+
+    for (const serviceDef of definition.services) {
+        for (const endpoint of serviceDef.endpoints) {
+            for (const arg of endpoint.args) {
+                if (hasNestedOptional(arg.type, knownTypes, false)) {
+                    throw new Error(
+                        `Nested optionals not allowed: arg '${arg.argName}' ` +
+                            `in endpoint '${endpoint.endpointName}' of service '${serviceDef.serviceName.name}'`,
+                    );
+                }
+            }
+            if (endpoint.returns != null && hasNestedOptional(endpoint.returns, knownTypes, false)) {
+                throw new Error(
+                    `Nested optionals not allowed: return type of endpoint '${endpoint.endpointName}' ` +
+                        `in service '${serviceDef.serviceName.name}'`,
+                );
+            }
+        }
+    }
+}
+
+// --- IllegalMapKeyValidator ---
+
+function hasIllegalMapKey(type: IType, knownTypes: Map<string, ITypeDefinition>): boolean {
+    if (IType.isMap(type)) {
+        const keyType = type.map.keyType;
+        // Map keys must be primitives or references (enums/objects after dealiasing)
+        if (!IType.isPrimitive(keyType) && !IType.isReference(keyType)) {
+            return true;
+        }
+        // Also check value recursively
+        return hasIllegalMapKey(type.map.valueType, knownTypes);
+    }
+    if (IType.isOptional(type)) {
+        return hasIllegalMapKey(type.optional.itemType, knownTypes);
+    }
+    if (IType.isList(type)) {
+        return hasIllegalMapKey(type.list.itemType, knownTypes);
+    }
+    if (IType.isSet(type)) {
+        return hasIllegalMapKey(type.set.itemType, knownTypes);
+    }
+    return false;
+}
+
+export function validateNoIllegalMapKeys(
+    definition: IConjureDefinition,
+    knownTypes: Map<string, ITypeDefinition>,
+): void {
+    for (const typeDef of definition.types) {
+        if (ITypeDefinition.isObject(typeDef)) {
+            for (const field of typeDef.object.fields) {
+                if (hasIllegalMapKey(field.type, knownTypes)) {
+                    throw new Error(
+                        `Complex type not allowed in map key: field '${field.fieldName}' ` +
+                            `in type '${typeDef.object.typeName.name}'`,
+                    );
+                }
+            }
+        } else if (ITypeDefinition.isUnion(typeDef)) {
+            for (const member of typeDef.union.union) {
+                if (hasIllegalMapKey(member.type, knownTypes)) {
+                    throw new Error(
+                        `Complex type not allowed in map key: member '${member.fieldName}' ` +
+                            `in union '${typeDef.union.typeName.name}'`,
+                    );
+                }
+            }
+        } else if (ITypeDefinition.isAlias(typeDef)) {
+            if (hasIllegalMapKey(typeDef.alias.alias, knownTypes)) {
+                throw new Error(`Complex type not allowed in map key: alias '${typeDef.alias.typeName.name}'`);
+            }
+        }
+    }
+}

--- a/src/utils/validators/typeValidator.ts
+++ b/src/utils/validators/typeValidator.ts
@@ -51,10 +51,7 @@ export function dealias(type: IType, knownTypes: Map<string, ITypeDefinition>): 
 /**
  * Check if a type resolves to a TypeDefinition (returns the definition), or to a primitive/container (returns undefined).
  */
-export function dealiasToDefinition(
-    type: IType,
-    knownTypes: Map<string, ITypeDefinition>,
-): ITypeDefinition | undefined {
+function dealiasToDefinition(type: IType, knownTypes: Map<string, ITypeDefinition>): ITypeDefinition | undefined {
     if (IType.isReference(type)) {
         const refName = createHashableTypeName(type.reference);
         const typeDef = knownTypes.get(refName);
@@ -331,6 +328,37 @@ export function validateNoIllegalMapKeys(
         } else if (ITypeDefinition.isAlias(typeDef)) {
             if (hasIllegalMapKey(typeDef.alias.alias, knownTypes)) {
                 throw new Error(`Complex type not allowed in map key: alias '${typeDef.alias.typeName.name}'`);
+            }
+        }
+    }
+
+    for (const errorDef of definition.errors) {
+        const allArgs = (errorDef.safeArgs || []).concat(errorDef.unsafeArgs || []);
+        for (const arg of allArgs) {
+            if (hasIllegalMapKey(arg.type, knownTypes)) {
+                throw new Error(
+                    `Complex type not allowed in map key: arg '${arg.fieldName}' ` +
+                        `in error '${errorDef.errorName.name}'`,
+                );
+            }
+        }
+    }
+
+    for (const serviceDef of definition.services) {
+        for (const endpoint of serviceDef.endpoints) {
+            for (const arg of endpoint.args) {
+                if (hasIllegalMapKey(arg.type, knownTypes)) {
+                    throw new Error(
+                        `Complex type not allowed in map key: arg '${arg.argName}' ` +
+                            `in endpoint '${endpoint.endpointName}' of service '${serviceDef.serviceName.name}'`,
+                    );
+                }
+            }
+            if (endpoint.returns != null && hasIllegalMapKey(endpoint.returns, knownTypes)) {
+                throw new Error(
+                    `Complex type not allowed in map key: return type of endpoint '${endpoint.endpointName}' ` +
+                        `in service '${serviceDef.serviceName.name}'`,
+                );
             }
         }
     }

--- a/src/utils/validators/unionValidator.ts
+++ b/src/utils/validators/unionValidator.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Direct port of conjure-core UnionDefinitionValidator.java
+// Three sub-validators: KeySyntax, NoTrailingUnderscore, NoClobberType
+
+import { IUnionDefinition } from "conjure-api";
+
+// Port of Character.isJavaIdentifierStart / isJavaIdentifierPart
+// Java identifiers allow: letters, digits, _, $
+// Start must be: letter, _, $
+function isJavaIdentifierStart(ch: string): boolean {
+    return (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z") || ch === "_" || ch === "$";
+}
+
+function isJavaIdentifierPart(ch: string): boolean {
+    return isJavaIdentifierStart(ch) || (ch >= "0" && ch <= "9");
+}
+
+function isValidJavaIdentifier(key: string): boolean {
+    if (key.length === 0 || !isJavaIdentifierStart(key[0])) {
+        return false;
+    }
+    for (let i = 1; i < key.length; i++) {
+        if (!isJavaIdentifierPart(key[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Port of UnionDefinitionValidator.KeySyntaxValidator
+function validateKeySyntax(fieldName: string, context: string): void {
+    if (fieldName.length === 0) {
+        throw new Error(`Union member key must not be empty in ${context}`);
+    }
+    if (!isValidJavaIdentifier(fieldName)) {
+        throw new Error(`Union member key must be a valid Java identifier: "${fieldName}" in ${context}`);
+    }
+}
+
+// Port of UnionDefinitionValidator.NoTrailingUnderscoreValidator
+function validateNoTrailingUnderscore(fieldName: string, context: string): void {
+    if (fieldName.endsWith("_")) {
+        throw new Error(`Union member key must not end with an underscore: "${fieldName}" in ${context}`);
+    }
+}
+
+// Port of UnionDefinitionValidator.NoClobberTypeValidator
+function validateNoClobberType(fieldName: string, context: string): void {
+    if (fieldName === "type") {
+        throw new Error(`Union member key must not be 'type' in ${context}`);
+    }
+}
+
+// Port of UnionDefinitionValidator.validateAll()
+export function validateUnionDefinition(definition: IUnionDefinition): void {
+    const context = `union ${definition.typeName.name}`;
+    for (const fieldDef of definition.union) {
+        validateKeySyntax(fieldDef.fieldName, context);
+        validateNoTrailingUnderscore(fieldDef.fieldName, context);
+        validateNoClobberType(fieldDef.fieldName, context);
+    }
+}


### PR DESCRIPTION
## Before this PR
Malicious IR payloads can lead to RCE. 

## After this PR
Summary

  This PR adds a 1:1 port of conjure-core's ConjureDefinitionValidator to TypeScript, validating Conjure IR definitions before code generation. This closes the code injection vector reported in the bug bounty — previously, IR-supplied
  identifiers (type names, field names, endpoint names, paths, etc.) were interpolated raw into generated TypeScript via ts-morph, which performs zero input sanitization.

  What this does

  Validates all IR inputs before they reach the code generator, matching the same checks the Java Conjure compiler enforces at compile time. Since conjure-typescript consumes pre-compiled IR (not .conjure source files), it was previously
  trusting that the IR was well-formed. A malicious or corrupted IR file could inject arbitrary code into generated .ts files.

  Validators ported (matching Java):
  - Top-level orchestrator (conjureValidator.ts): unique names, no recursive types, no nested optionals, no illegal map keys
  - Per-type: type name format, package name format, enum values, union members, object field names
  - Per-service: service name format, unique endpoint names, unique path+method combos, HTTP path structure
  - Per-endpoint (endpointValidator.ts): all 13 sub-validators from EndpointDefinitionValidator.java — body param rules, path/header/query param type constraints, bearer token restrictions, parameter name casing, header/query paramId format,
  HTTP method validation, duplicate error detection
  - Per-error: error code, namespace, field names, safety declaration consistency

  Intentional deviations from Java:
  - LogSafetyConjureDefinitionValidator is skipped — it's gated by a SafetyDeclarationRequirements config flag that is a compile-time policy concern. The Conjure compiler already enforces this before emitting IR.
  - IllegalVersionValidator is skipped — IR version checking is out of scope for the code generator.

  Open question: endpointName validation. Java validates endpoint names at the parser level (EndpointName.of() enforces camelCase), not in EndpointDefinitionValidator. Since we consume pre-compiled IR, endpointName reaches us without this
  parser-level check and flows directly into generated TypeScript method names. This PR adds a defense-in-depth validateEndpointName() check in the endpoint validator that enforces camelCase — this goes beyond what
  EndpointDefinitionValidator.java does. Should we keep this, or rely on the assumption that IR producers have already validated endpoint names?

  Defense in depth

  The existing quotesUtils.ts string escaping remains as a secondary safety net behind the new input validation. The approach is: validate → reject bad input early, escape → prevent damage if something slips through.


## Possible downsides?
Mistake in port, might reject valid inputs. 

